### PR TITLE
bug: fixing null index hash in search fetch

### DIFF
--- a/src/client/theme/SearchBar/fetchIndexes.ts
+++ b/src/client/theme/SearchBar/fetchIndexes.ts
@@ -18,8 +18,11 @@ export async function fetchIndexes(baseUrl: string): Promise<{
   zhDictionary: string[];
 }> {
   // if (process.env.NODE_ENV === "production") {
+  const indexUrl = `${baseUrl}search-index.json`;
+  const queryString = indexHash ? `?_=${indexHash}` : "";
+
   const json = (await (
-    await fetch(`${baseUrl}search-index.json?_=${indexHash}`)
+    await fetch(`${indexUrl}${queryString}`)
   ).json()) as SerializedIndex[];
 
   const wrappedIndexes: WrappedIndex[] = json.map(

--- a/src/client/utils/__mocks__/proxiedGenerated.ts
+++ b/src/client/utils/__mocks__/proxiedGenerated.ts
@@ -1,17 +1,21 @@
 export let language = ["en", "zh"];
 export let removeDefaultStopWordFilter = false;
-export const indexHash = "abc";
+export let indexHash: string | null = "abc";
 export const searchResultLimits = 8;
 export const searchResultContextMaxLength = 50;
 export const translations = {
-  "search_placeholder": "Search",
-  "see_all_results": "See all results",
-  "no_results": "No results.",
-  "search_results_for": "Search results for \"{{ keyword }}\"",
-  "search_the_documentation": "Search the documentation",
-  "count_documents_found": "{{ count }} document found",
-  "count_documents_found_plural": "{{ count }} documents found",
-  "no_documents_were_found": "No documents were found"
+  search_placeholder: "Search",
+  see_all_results: "See all results",
+  no_results: "No results.",
+  search_results_for: 'Search results for "{{ keyword }}"',
+  search_the_documentation: "Search the documentation",
+  count_documents_found: "{{ count }} document found",
+  count_documents_found_plural: "{{ count }} documents found",
+  no_documents_were_found: "No documents were found",
+};
+
+export function __setHash(value: string | null): void {
+  indexHash = value;
 }
 
 export function __setLanguage(value: string[]): void {

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -1,10 +1,3 @@
-declare module "@docusaurus/router" {
-  export const useHistory: () => {
-    push: (url: string) => void;
-    replace: (args: any) => void;
-  };
-}
-
 declare module "*/generated.js" {
   export const language: string[];
   export const removeDefaultStopWordFilter: string[];
@@ -13,16 +6,15 @@ declare module "*/generated.js" {
     mark: (terms: string[], options?: Record<string, unknown>) => void;
     unmark: () => void;
   }
-  export const indexHash: string | undefined;
+  export const indexHash: string | null;
   export const searchResultLimits: number;
   export const searchResultContextMaxLength: number;
   export const translations: Required<TranslationMap>;
   // These below are for mocking only.
+  export const __setHash: (value: string | null) => void;
   export const __setLanguage: (value: string[]) => void;
   export const __setRemoveDefaultStopWordFilter: (value: boolean) => void;
 }
-
-declare module "@docusaurus/Head";
 
 declare interface TranslationMap {
   search_placeholder?: string;


### PR DESCRIPTION
## Summary

When there is no index hash, the generation code sets it to null in the generated file. This PR removes `?_=null` from the search fetch in the browser when there is no index hash generated.