### PR TITLE
fix: remove overflow-y from searchResultsSection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docusaurus-plugin-search-local",
-  "version": "0.2.1",
+  "version": "0.3.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "docusaurus-plugin-search-local",
-      "version": "0.2.1",
+      "version": "0.3.0-beta.1",
       "license": "MIT",
       "workspaces": [
         "website"
@@ -33,7 +33,6 @@
         "@babel/preset-typescript": "^7.12.1",
         "@parcel/css": "^1.3.2",
         "@parcel/css-cli": "^1.3.2",
-        "@parcel/reporter-cli": "^2.3.1",
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.2",
         "@tsconfig/docusaurus": "^1.0.2",
@@ -29991,7 +29990,6 @@
         "@docusaurus/utils-validation": "^2.0.0-beta.14",
         "@parcel/css": "^1.3.2",
         "@parcel/css-cli": "^1.3.2",
-        "@parcel/reporter-cli": "*",
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.2",
         "@tsconfig/docusaurus": "^1.0.2",

--- a/src/client/theme/SearchModal/index.module.css
+++ b/src/client/theme/SearchModal/index.module.css
@@ -126,7 +126,6 @@
 
 /* SearchResultSection Component */
 .searchResultsSection {
-  overflow-y: scroll;
   max-height: 400px;
   color: var(--search-local-text-color);
 }

--- a/src/server/utils/__tests__/__snapshots__/getGlobalPluginData.test.ts.snap
+++ b/src/server/utils/__tests__/__snapshots__/getGlobalPluginData.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`getGlobalPluginData it should generate an index hash when enabled 1`] = `
 Object {
   "externalSearchSources": Array [],
-  "indexHash": "3b20f5e8",
+  "indexHash": "5f18df3a",
   "removeDefaultStopWordFilter": false,
   "searchResultContextMaxLength": 50,
   "searchResultLimits": 8,
@@ -23,7 +23,7 @@ Object {
 exports[`getGlobalPluginData it should only index blog when enabled 1`] = `
 Object {
   "externalSearchSources": Array [],
-  "indexHash": "8845f751",
+  "indexHash": "ba8eaf78",
   "removeDefaultStopWordFilter": false,
   "searchResultContextMaxLength": 50,
   "searchResultLimits": 8,
@@ -43,7 +43,7 @@ Object {
 exports[`getGlobalPluginData it should only index docs when enabled 1`] = `
 Object {
   "externalSearchSources": Array [],
-  "indexHash": "c4002c70",
+  "indexHash": "31ed3b74",
   "removeDefaultStopWordFilter": false,
   "searchResultContextMaxLength": 50,
   "searchResultLimits": 8,


### PR DESCRIPTION
## Summary

Causing scrollbar to show for each search result

### Before
![Screen Shot 2022-02-16 at 5 48 04 PM](https://user-images.githubusercontent.com/1854811/154388883-5c7b324b-ae3b-42c5-97cb-68af1cab9c50.png)

### After
![Screen Shot 2022-02-16 at 5 48 19 PM](https://user-images.githubusercontent.com/1854811/154388893-43efdd75-a673-4f4e-b39a-4cba4b82cf2f.png)

