### PR TITLE
fix: Fixing no docs found text

### DIFF
--- a/src/client/theme/SearchModal/SearchModal.tsx
+++ b/src/client/theme/SearchModal/SearchModal.tsx
@@ -277,31 +277,21 @@ const SearchModal: React.FC<SearchModalProps> = ({
               <p>Please provide a search query to show results.</p>
             </div>
           ) : (
-            ""
-          )}
-          {searchResults.length === 0 ? (
-            process.env.NODE_ENV === "production" ? (
-              <div className={styles.messageContainer}>
-                <p>{translations.no_documents_were_found}</p>
-              </div>
-            ) : (
-              <div className={styles.messageContainer}>
-                <p>
-                  ⚠️ The search index is only available when you run docusaurus
-                  build!
-                </p>
-              </div>
-            )
-          ) : (
             <SearchResultsSection heading={title}>
-              <SearchResultList
-                results={searchResults}
-                currentSelection={selected}
-                cursor={cursor}
-                onSearchResultClick={onClose}
-                setHovered={setHovered}
-                setSelected={setSelected}
-              />
+              {searchResults.length === 0 ? (
+                <em className={styles.noDocsFoundMessage}>
+                  {translations.no_documents_were_found}
+                </em>
+              ) : (
+                <SearchResultList
+                  results={searchResults}
+                  currentSelection={selected}
+                  cursor={cursor}
+                  onSearchResultClick={onClose}
+                  setHovered={setHovered}
+                  setSelected={setSelected}
+                />
+              )}
             </SearchResultsSection>
           )}
 

--- a/src/client/theme/SearchModal/index.module.css
+++ b/src/client/theme/SearchModal/index.module.css
@@ -72,6 +72,13 @@
   color: var(--search-local-text-color);
 }
 
+.noDocsFoundMessage {
+  display: flex;
+  justify-content: space-around;
+  font-weight: 300;
+  color: var(--search-local-text-color);
+}
+
 .searchResultsContainer {
   overflow-y: overlay;
   max-height: 400px;


### PR DESCRIPTION
## Summary

Fixing "No documents were found" text when searching inside the modal.

## Details

* Moved around log for when to show the no-docs text.
* Removed unecessary styling for the scenario.

## Before

<img width="603" alt="before-no-docs-found" src="https://user-images.githubusercontent.com/702906/154559705-95a30e67-0fa7-4822-b953-72466f68eac5.png">

## After

<img width="1288" alt="after-no-docs-found" src="https://user-images.githubusercontent.com/702906/154559697-3f95d22f-fcfb-4292-be5b-f44988de8cee.png">

Fixes #26

