### PR TITLE
fix: using infima colors instead of custom colors

### DIFF
--- a/src/client/theme/LoadingRing/LoadingRing.module.css
+++ b/src/client/theme/LoadingRing/LoadingRing.module.css
@@ -14,15 +14,11 @@
   width: 16px;
   height: 16px;
   margin: 2px;
-  border: 2px solid
-    var(--search-load-loading-icon-color, var(--ifm-navbar-search-input-color));
+  border: 2px solid var(--ifm-navbar-search-input-color);
   border-radius: 50%;
   animation: loading-ring 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
-  border-color: var(
-      --search-load-loading-icon-color,
-      var(--ifm-navbar-search-input-color)
-    )
-    transparent transparent transparent;
+  border-color: var(--ifm-navbar-search-input-color) transparent transparent
+    transparent;
 }
 
 .loadingRing div:nth-child(1) {

--- a/src/client/theme/SearchBar/SearchButton.css
+++ b/src/client/theme/SearchBar/SearchButton.css
@@ -1,34 +1,8 @@
 :root {
-  --search-local-primary-color: rgb(84, 104, 255);
-  --search-local-text-color: rgb(28, 30, 33);
-  --search-local-spacing: 12px;
   --search-local-icon-stroke-width: 1.4;
-  --search-local-highlight-color: var(--search-local-primary-color);
-  --search-local-muted-color: rgb(150, 159, 175);
-  --search-local-container-background: rgba(101, 108, 133, 0.8);
-  --search-local-logo-color: rgba(84, 104, 255);
-
-  /* modal */
-  --search-local-modal-width: 560px;
-  --search-local-modal-height: 600px;
-  --search-local-modal-background: rgb(245, 246, 247);
-  --search-local-modal-shadow: inset 1px 1px 0 0 rgba(255, 255, 255, 0.5),
-    0 3px 8px 0 rgba(85, 90, 100, 1);
 
   /* searchbox */
-  --search-local-searchbox-height: 56px;
-  --search-local-searchbox-background: rgb(235, 237, 240);
-  --search-local-container-border: rgb(235, 237, 240, 0.25);
-  --search-local-searchbox-focus-background: rgb(235, 237, 240);
-  --search-local-searchbox-shadow: inset 0 0 0 2px
-    var(--search-local-primary-color);
-
-  /* hit */
-  --search-local-hit-height: 56px;
-  --search-local-hit-color: rgb(68, 73, 80);
-  --search-local-hit-active-color: #fff;
-  --search-local-hit-background: #fff;
-  --search-local-hit-shadow: 0 1px 3px 0 rgb(212, 217, 225);
+  --search-local-searchbox-shadow: inset 0 0 0 2px var(--ifm-color-primary);
 
   /* key */
   --search-local-key-gradient: linear-gradient(
@@ -38,48 +12,27 @@
   );
   --search-local-key-shadow: inset 0 -2px 0 0 rgb(205, 205, 230),
     inset 0 0 1px 1px #fff, 0 1px 2px 1px rgba(30, 35, 90, 0.4);
-
-  /* footer */
-  --search-local-footer-height: 44px;
-  --search-local-footer-background: #fff;
-  --search-local-footer-shadow: 0 -1px 0 0 rgb(224, 227, 232),
-    0 -3px 6px 0 rgba(69, 98, 155, 0.12);
 }
 
 /* Darkmode */
 
 html[data-theme="dark"] {
-  --search-local-text-color: rgb(245, 246, 247);
-  --search-local-container-background: rgba(9, 10, 17, 0.8);
-  --search-local-container-border: rgba(9, 10, 17, 0.9);
-  --search-local-modal-background: rgb(36, 37, 38);
-  --search-local-modal-shadow: inset 1px 1px 0 0 rgb(44, 46, 64),
-    0 3px 8px 0 rgb(0, 3, 9);
-  --search-local-searchbox-background: rgb(9, 10, 17);
-  --search-local-searchbox-focus-background: rgb(9, 10, 17);
-  --search-local-hit-color: rgb(190, 195, 201);
-  --search-local-hit-shadow: none;
-  --search-local-hit-background: rgb(9, 10, 17);
   --search-local-key-gradient: linear-gradient(
     -26.5deg,
     rgb(86, 88, 114) 0%,
     rgb(49, 53, 91) 100%
   );
+
   --search-local-key-shadow: inset 0 -2px 0 0 rgb(40, 45, 85),
     inset 0 0 1px 1px rgb(81, 87, 125), 0 2px 2px 0 rgba(3, 4, 9, 0.3);
-  --search-local-footer-background: rgb(30, 33, 54);
-  --search-local-footer-shadow: inset 0 1px 0 0 rgba(73, 76, 106, 0.5),
-    0 -4px 8px 0 rgba(0, 0, 0, 0.2);
-  --search-local-logo-color: rgb(255, 255, 255);
-  --search-local-muted-color: rgb(127, 132, 151);
 }
 
 .DocSearch-Button {
   align-items: center;
-  background: var(--search-local-searchbox-background);
+  background: var(--ifm-navbar-search-input-background-color);
   border: 0;
   border-radius: 40px;
-  color: var(--search-local-muted-color);
+  color: var(--ifm-navbar-search-input-color);
   cursor: pointer;
   display: flex;
   font-weight: 500;
@@ -93,9 +46,7 @@ html[data-theme="dark"] {
 .DocSearch-Button:hover,
 .DocSearch-Button:active,
 .DocSearch-Button:focus {
-  background: var(--search-local-searchbox-focus-background);
   box-shadow: var(--search-local-searchbox-shadow);
-  color: var(--search-local-text-color);
   outline: none;
 }
 
@@ -109,7 +60,7 @@ html[data-theme="dark"] {
 }
 
 .DocSearch-Button .DocSearch-Search-Icon {
-  color: var(--search-local-text-color);
+  color: var(--ifm-font-color-base);
 }
 
 .DocSearch-Button-Placeholder {
@@ -128,7 +79,7 @@ html[data-theme="dark"] {
   background: var(--search-local-key-gradient);
   border-radius: 3px;
   box-shadow: var(--search-local-key-shadow);
-  color: var(--search-local-muted-color);
+  color: var(--ifm-color-secondary-darkest);
   display: flex;
   height: 18px;
   justify-content: center;

--- a/src/client/theme/SearchModal/index.module.css
+++ b/src/client/theme/SearchModal/index.module.css
@@ -1,3 +1,13 @@
+/* Variables */
+:root {
+  --search-local-result-height: 56px;
+  --search-local-result-shadow: 0 1px 3px 0 rgb(212, 217, 225);
+}
+
+html[data-theme="dark"] {
+  --search-local-result-shadow: none;
+}
+
 /* SearchModal Component */
 .searchModal {
   position: fixed;
@@ -12,7 +22,7 @@
 .searchModalContainer {
   box-shadow: rgba(255, 255, 255, 0.5) 1px 1px 0px 0px inset,
     rgb(85, 90, 100) 0px 3px 8px 0px;
-  background: var(--search-local-modal-background);
+  background: var(--ifm-color-primary-contrast-background);
   position: relative;
 
   flex-direction: column;
@@ -21,7 +31,7 @@
   width: 50%;
   min-width: 400px;
   min-height: 200px;
-  border: 1px solid var(--search-local-container-border);
+  border: 1px solid var(--ifm-color-primary-contrast-background);
 }
 
 .searchInputContainer {
@@ -31,13 +41,12 @@
   align-items: center;
   box-shadow: var(--search-local-searchbox-shadow);
   border-radius: 4px;
-  background-color: var(--search-local-searchbox-focus-background);
+  background-color: var(--ifm-navbar-search-input-background-color);
 }
 
 .searchInputContainer label {
   margin-left: 10px;
   margin-right: 5px;
-  color: var(--search-local-text-color);
   display: flex;
 }
 
@@ -54,7 +63,7 @@
   position: relative;
   width: 100%;
   height: 100%;
-  color: var(--search-local-text-color);
+  color: var(--ifm-font-color-base);
   font-size: 1.2em;
   border: none;
   outline: none;
@@ -69,26 +78,29 @@
   justify-content: space-around;
   align-items: center;
   font-weight: 300;
-  color: var(--search-local-text-color);
 }
 
 .noDocsFoundMessage {
   display: flex;
   justify-content: space-around;
   font-weight: 300;
-  color: var(--search-local-text-color);
 }
 
 .searchResultsContainer {
-  overflow-y: overlay;
+  overflow-y: scroll;
   max-height: 400px;
-  color: var(--search-local-text-color);
   padding-left: 12px;
   padding-right: 12px;
 }
 
+@media screen and (-webkit-min-device-pixel-ratio: 0) and (min-resolution: 0.001dpcm) {
+  .searchResultsContainer {
+    overflow-y: overlay;
+  }
+}
+
 .searchResultsContainer::-webkit-scrollbar {
-  width: 12px;
+  width: 6px;
 }
 
 .searchResultsContainer::-webkit-scrollbar-track {
@@ -96,18 +108,16 @@
 }
 
 .searchResultsContainer::-webkit-scrollbar-thumb {
-  background-color: var(--search-local-muted-color);
-  border: 3px solid var(--search-local-modal-background);
+  background-color: var(--ifm-color-secondary-darkest);
   border-radius: 20px;
 }
 
 .searchResultsContainerFooter {
-  color: var(--search-local-muted-color);
+  color: var(--ifm-color-secondary-darkest);
   display: flex;
   font-size: 0.85em;
   justify-content: center;
-  margin-bottom: var(--search-local-spacing);
-  padding: var(--search-local-spacing);
+  padding: var(--ifm-global-spacing);
 }
 
 .searchResultsContainerFooter a {
@@ -134,7 +144,7 @@
 /* SearchResultSection Component */
 .searchResultsSection {
   max-height: 400px;
-  color: var(--search-local-text-color);
+  padding-bottom: 4px;
 }
 
 .searchResultsSection:last-of-type {
@@ -142,13 +152,12 @@
 }
 
 .searchResultsSectionHeader {
-  background: var(--search-local-modal-background);
-  color: var(--search-local-text-color);
+  background: var(--ifm-color-primary-contrast-background);
   font-size: 0.85em;
   font-weight: 600;
   line-height: 32px;
   margin: 0 -4px;
-  padding: 8px 4px 0;
+  padding: 4px 4px 0;
   position: -webkit-sticky;
   position: sticky;
   top: 0;
@@ -158,34 +167,26 @@
 /* SearchResult Component */
 .searchResult {
   cursor: pointer;
-  background: var(--search-local-hit-background, #fff);
+  background: var(--ifm-background-surface-color);
   border-radius: 4px;
-  box-shadow: var(--search-local-hit-shadow, 0 1px 3px 0 #d4d9e1);
-  padding: 0 var(--search-local-spacing, 12px);
+  box-shadow: var(--search-local-result-shadow, 0 1px 3px 0 #d4d9e1);
+  margin-bottom: 4px;
+  padding: 0 var(--ifm-global-spacing);
   width: 100%;
-
   align-items: center;
-  color: var(--search-local-hit-color, #444950);
+  color: var(--ifm-font-color-base);
   display: flex;
   flex-direction: row;
-  height: var(--search-local-hit-height, 56px);
+  height: var(--search-local-result-height, 56px);
 }
 
 html[data-theme="dark"] .searchResult {
-  background: var(--search-local-hit-background, var(--ifm-color-emphasis-100));
-  box-shadow: var(--search-local-hit-shadow, none);
-  color: var(--search-local-hit-color, var(--ifm-font-color-base));
-}
-
-.searchResult:not(:last-child) {
-  margin-bottom: 4px;
+  box-shadow: var(--search-local-result-shadow, none);
+  color: var(--ifm-font-color-base);
 }
 
 .cursor {
-  background-color: var(
-    --search-local-highlight-color,
-    var(--ifm-color-primary)
-  ) !important;
+  background-color: var(--ifm-color-primary) !important;
 }
 
 .cursor > span {
@@ -200,13 +201,13 @@ html[data-theme="dark"] .searchResult {
 .hitTree,
 .hitIcon,
 .hitPath {
-  color: var(--search-local-muted-color, #969faf);
+  color: var(--ifm-color-secondary-darkest);
 }
 
 html[data-theme="dark"] .hitTree,
 html[data-theme="dark"] .hitIcon,
 html[data-theme="dark"] .hitPath {
-  color: var(--search-local-muted-color, var(--ifm-color-secondary-darkest));
+  color: var(--ifm-color-secondary-darkest);
 }
 
 .hitTree {
@@ -215,7 +216,7 @@ html[data-theme="dark"] .hitPath {
 }
 
 .hitTree > svg {
-  height: var(--search-local-hit-height, 56px);
+  height: var(--search-local-result-height, 56px);
   opacity: 0.5;
   stroke-width: var(--search-local-icon-stroke-width, 1.4);
   width: 24px;
@@ -241,7 +242,7 @@ html[data-theme="dark"] .hitPath {
 
 .hitWrapper mark {
   background: none;
-  color: var(--search-local-highlight-color, var(--ifm-color-primary));
+  color: var(--ifm-color-primary);
 }
 
 .hitTitle {


### PR DESCRIPTION
## Summary

Use `infima` variables over custom variables where appropriate.

## Testing Done

Verified colors in Chrome/Brave/Firefox locally.

### Before

<img width="606" alt="Screen Shot 2022-02-22 at 2 42 53 PM" src="https://user-images.githubusercontent.com/702906/155232024-b6ab22f8-6310-4b7e-99e4-c7ee6ba0498d.png">

### After

<img width="618" alt="Screen Shot 2022-02-22 at 2 41 44 PM" src="https://user-images.githubusercontent.com/702906/155232001-213314ed-cd29-4d39-a3e0-3ea6c1772137.png">

Resolves #31 
