### PR TITLE
fix: handle errors when fetching search index

### DIFF
--- a/src/client/utils/__tests__/__fixtures__/search-index.json
+++ b/src/client/utils/__tests__/__fixtures__/search-index.json
@@ -1,0 +1,27 @@
+[
+  {
+    "documents": [
+      {
+        "i": 12,
+        "t": "Installation",
+        "u": "/docusaurus-plugin-search-local/docs/getting-started/",
+        "h": "#installation",
+        "p": 10
+      }
+    ],
+    "index": {
+      "version": "2.3.9",
+      "fields": ["t"],
+      "fieldVectors": [
+        ["t/12", [0, 0.981]],
+        ["t/14", [1, 0.981]],
+        ["t/16", [2, 0.981]]
+      ],
+      "invertedIndex": [
+        ["hello", { "_index": 1, "t": { "14": { "position": [[0, 13]] } } }],
+        ["world", { "_index": 0, "t": { "12": { "position": [[0, 12]] } } }]
+      ],
+      "pipeline": ["stemmer"]
+    }
+  }
+]

--- a/src/client/utils/__tests__/__snapshots__/fetchIndexes.test.ts.snap
+++ b/src/client/utils/__tests__/__snapshots__/fetchIndexes.test.ts.snap
@@ -1,0 +1,104 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`fetchIndexes it should handle endpoint errors 1`] = `
+Object {
+  "wrappedIndexes": Array [],
+}
+`;
+
+exports[`fetchIndexes it should handle errors parsing the search index file 1`] = `
+Object {
+  "wrappedIndexes": Array [],
+}
+`;
+
+exports[`fetchIndexes production 1`] = `
+Object {
+  "wrappedIndexes": Array [
+    Object {
+      "documents": Array [
+        Object {
+          "h": "#installation",
+          "i": 12,
+          "p": 10,
+          "t": "Installation",
+          "u": "/docusaurus-plugin-search-local/docs/getting-started/",
+        },
+      ],
+      "index": Object {
+        "fieldVectors": Array [
+          Array [
+            "t/12",
+            Array [
+              0,
+              0.981,
+            ],
+          ],
+          Array [
+            "t/14",
+            Array [
+              1,
+              0.981,
+            ],
+          ],
+          Array [
+            "t/16",
+            Array [
+              2,
+              0.981,
+            ],
+          ],
+        ],
+        "fields": Array [
+          "t",
+        ],
+        "invertedIndex": Array [
+          Array [
+            "hello",
+            Object {
+              "_index": 1,
+              "t": Object {
+                "14": Object {
+                  "position": Array [
+                    Array [
+                      0,
+                      13,
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          Array [
+            "world",
+            Object {
+              "_index": 0,
+              "t": Object {
+                "12": Object {
+                  "position": Array [
+                    Array [
+                      0,
+                      12,
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+        ],
+        "pipeline": Array [
+          "stemmer",
+        ],
+        "version": "2.3.9",
+      },
+      "type": 0,
+    },
+  ],
+}
+`;
+
+exports[`fetchIndexes production with empty index 1`] = `
+Object {
+  "wrappedIndexes": Array [],
+}
+`;

--- a/tsconfig.client.json
+++ b/tsconfig.client.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "ESNext",
-    "target": "ESNext"
+    "target": "ESNext",
+    "types": ["cheerio", "@docusaurus/module-type-aliases", "jest"]
   },
   "include": ["src/client/", "src/*.ts"]
 }


### PR DESCRIPTION
## Summary

Handle errors when fetching search index files.

## Testing Done

Wrote unit tests, ran local website with forced endpoint errors.

Fixes #37 