### PR TITLE
fix: ensures urls with overlapping segments doesn't remove the protocol

### DIFF
--- a/src/client/utils/__tests__/getExternalURI.test.ts
+++ b/src/client/utils/__tests__/getExternalURI.test.ts
@@ -78,6 +78,13 @@ describe("getExternalURI", () => {
     expect(getExternalURI("/foo/bar/graphql", "www.example.com/foo/bar/")).toBe(
       "www.example.com/foo/bar/graphql"
     );
+
+    expect(
+      getExternalURI(
+        "/some-rando/location/foo",
+        "https://www.foo.bar.example.com/some-rando/location/"
+      )
+    ).toBe("https://www.foo.bar.example.com/some-rando/location/foo");
   });
 
   test("it should handle a url with same parts but not overlapping", () => {

--- a/src/client/utils/getExternalURI.ts
+++ b/src/client/utils/getExternalURI.ts
@@ -2,7 +2,6 @@ import { sanitizeUrl } from "@braintree/sanitize-url";
 
 const END_SLASH_PATTERN = /\/$/;
 const START_SLASH_PATTERN = /^\//;
-const PROTOCOL_PATTERN = /^http[s]?:\/\//;
 
 function isBaseOverlapping(baseParts: string[], routeParts: string[]): boolean {
   const base = baseParts.join("");
@@ -20,7 +19,7 @@ export function getExternalURI(documentPath: string, baseURI: string): string {
   const base = sanitizedBase.replace(END_SLASH_PATTERN, "");
   const route = sanitizedRoute.replace(START_SLASH_PATTERN, "");
 
-  const baseParts = base.replace(PROTOCOL_PATTERN, "").split("/");
+  const baseParts = base.split("/");
   const routeParts = route.split("/");
 
   let externalBase = base;


### PR DESCRIPTION
## Summary

Ensures that urls that have overlapping segments with external URL segments do not have their protocol removed.