### PR TITLE
fix: highlight functionality is not guarded by option passed in

### DIFF
--- a/src/client/theme/SearchBar/SearchBar.tsx
+++ b/src/client/theme/SearchBar/SearchBar.tsx
@@ -1,8 +1,10 @@
 import React, { ReactElement, useEffect, useState } from "react";
 
 import { useLocation } from "@docusaurus/router";
-
+import { usePluginData } from "@docusaurus/useGlobalData";
 import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
+
+import { GlobalPluginData } from "docusaurus-plugin-search-local";
 
 import { SearchButton } from "./SearchButton";
 import SearchModal from "../SearchModal";
@@ -35,27 +37,33 @@ export default class SearchBarWrapper extends React.Component {
 }
 
 export function SearchBar(): ReactElement {
+  const { highlightSearchTermsOnTargetPage } = usePluginData(
+    "docusaurus-plugin-search-local"
+  ) as GlobalPluginData;
+
   const [isOpen, setIsOpen] = useState(false);
   const location = useLocation();
 
   useEffect(() => {
-    if (!Mark) {
-      return;
+    if (highlightSearchTermsOnTargetPage) {
+      if (!Mark) {
+        return;
+      }
+      const keywords = ExecutionEnvironment.canUseDOM
+        ? new URLSearchParams(location.search).getAll(SEARCH_PARAM_HIGHLIGHT)
+        : [];
+      if (keywords.length === 0) {
+        return;
+      }
+      const root = document.querySelector("article");
+      if (!root) {
+        return;
+      }
+      const mark = new Mark(root);
+      mark.unmark();
+      mark.mark(keywords);
     }
-    const keywords = ExecutionEnvironment.canUseDOM
-      ? new URLSearchParams(location.search).getAll(SEARCH_PARAM_HIGHLIGHT)
-      : [];
-    if (keywords.length === 0) {
-      return;
-    }
-    const root = document.querySelector("article");
-    if (!root) {
-      return;
-    }
-    const mark = new Mark(root);
-    mark.unmark();
-    mark.mark(keywords);
-  }, [location.search]);
+  }, [highlightSearchTermsOnTargetPage, location.search]);
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {

--- a/src/client/theme/SearchModal/SearchResult.tsx
+++ b/src/client/theme/SearchModal/SearchResult.tsx
@@ -51,9 +51,12 @@ function buildDestinationQueryParams(tokens: string[]): string {
 function handleExternalSearchClick(
   doc: SearchDocument,
   tokens: string[],
-  externalUriBase: string
+  externalUriBase: string,
+  shouldHighlight: boolean
 ) {
-  const queryParams = buildDestinationQueryParams(tokens);
+  const queryParams = shouldHighlight
+    ? buildDestinationQueryParams(tokens)
+    : "";
   const externalURI = `${getExternalURI(
     doc.u,
     externalUriBase
@@ -89,9 +92,8 @@ const SearchResult: React.FC<SuggestionTemplateProps> = (props) => {
     isLastOfTree,
   } = searchResult;
 
-  const { searchResultContextMaxLength } = usePluginData(
-    "docusaurus-plugin-search-local"
-  ) as GlobalPluginData;
+  const { searchResultContextMaxLength, highlightSearchTermsOnTargetPage } =
+    usePluginData("docusaurus-plugin-search-local") as GlobalPluginData;
   const history = useHistory();
   const isTitle = type === 0;
   const isHeading = type === 1;
@@ -99,14 +101,19 @@ const SearchResult: React.FC<SuggestionTemplateProps> = (props) => {
   const _onClick = () => {
     // If there is a search source defined, open the link externally.
     if (searchSource.length) {
-      handleExternalSearchClick(document, tokens, searchSource);
+      handleExternalSearchClick(
+        document,
+        tokens,
+        searchSource,
+        highlightSearchTermsOnTargetPage
+      );
       return;
     }
 
     const { u, h } = document;
 
     let url = sanitizeUrl(u);
-    if (tokens.length > 0) {
+    if (tokens.length > 0 && highlightSearchTermsOnTargetPage) {
       url += `?${buildDestinationQueryParams(tokens)}`;
     }
     if (h) {

--- a/src/docusaurus-plugin-search-local.d.ts
+++ b/src/docusaurus-plugin-search-local.d.ts
@@ -20,6 +20,7 @@ declare module "docusaurus-plugin-search-local" {
     indexHash: string | null;
     removeDefaultStopWordFilter: boolean;
     searchResultContextMaxLength: number;
+    highlightSearchTermsOnTargetPage: boolean;
     searchResultLimits: number;
     translations: TranslationMap;
   };

--- a/src/server/utils/__snapshots__/getGlobalPluginData.test.ts.snap
+++ b/src/server/utils/__snapshots__/getGlobalPluginData.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`getGlobalPluginData > it should generate an index hash when enabled 1`] = `
 {
   "externalSearchSources": [],
+  "highlightSearchTermsOnTargetPage": false,
   "indexHash": "d44d5b03",
   "removeDefaultStopWordFilter": false,
   "searchResultContextMaxLength": 50,
@@ -23,6 +24,7 @@ exports[`getGlobalPluginData > it should generate an index hash when enabled 1`]
 exports[`getGlobalPluginData > it should only index blog when enabled 1`] = `
 {
   "externalSearchSources": [],
+  "highlightSearchTermsOnTargetPage": false,
   "indexHash": "b7a48170",
   "removeDefaultStopWordFilter": false,
   "searchResultContextMaxLength": 50,
@@ -43,6 +45,7 @@ exports[`getGlobalPluginData > it should only index blog when enabled 1`] = `
 exports[`getGlobalPluginData > it should only index docs when enabled 1`] = `
 {
   "externalSearchSources": [],
+  "highlightSearchTermsOnTargetPage": false,
   "indexHash": "cea88d6e",
   "removeDefaultStopWordFilter": false,
   "searchResultContextMaxLength": 50,

--- a/src/server/utils/getGlobalPluginData.test.ts
+++ b/src/server/utils/getGlobalPluginData.test.ts
@@ -76,6 +76,7 @@ describe("getGlobalPluginData", () => {
     expect(getGlobalPluginData(config)).toEqual({
       externalSearchSources: config.externalSearchSources,
       indexHash: null,
+      highlightSearchTermsOnTargetPage: config.highlightSearchTermsOnTargetPage,
       removeDefaultStopWordFilter: config.removeDefaultStopWordFilter,
       searchResultContextMaxLength: config.searchResultContextMaxLength,
       searchResultLimits: config.searchResultLimits,

--- a/src/server/utils/getGlobalPluginData.ts
+++ b/src/server/utils/getGlobalPluginData.ts
@@ -11,6 +11,7 @@ export function getGlobalPluginData(
     searchResultContextMaxLength,
     searchResultLimits,
     translations,
+    highlightSearchTermsOnTargetPage,
   } = pluginConfig;
 
   return {
@@ -19,6 +20,7 @@ export function getGlobalPluginData(
     searchResultContextMaxLength,
     searchResultLimits,
     translations,
+    highlightSearchTermsOnTargetPage,
     indexHash: getIndexHash(pluginConfig),
   };
 }


### PR DESCRIPTION
fixes #52 

# Summary

We were not guarding the highlight functionality by the plugin options when setting highlightSearchTermsOnTargetPage to false.

## Before

<img width="735" alt="Screenshot 2022-10-22 at 1 20 06 PM" src="https://user-images.githubusercontent.com/1854811/197360964-8089536c-5772-4c37-89c7-5eee5b34d300.png">

## After

<img width="618" alt="Screenshot 2022-10-22 at 1 20 24 PM" src="https://user-images.githubusercontent.com/1854811/197360970-1d162c02-8fc8-4547-90c0-a36961ca98f0.png">

