### PR TITLE
feat: allow search terms to exist in middle of word

### DIFF
--- a/src/client/theme/SearchPage/SearchPage.tsx
+++ b/src/client/theme/SearchPage/SearchPage.tsx
@@ -70,12 +70,6 @@ export default function SearchPage(): React.ReactElement {
   }, []);
 
   useEffect(() => {
-    if (searchValue && searchValue !== searchQuery) {
-      setSearchQuery(searchValue);
-    }
-  }, [searchQuery, searchValue]);
-
-  useEffect(() => {
     async function doFetchIndexes() {
       const { wrappedIndexes } = await fetchIndexes(baseUrl, indexHash);
       setSearchSource(() =>

--- a/src/client/utils/SearchSourceFactory.ts
+++ b/src/client/utils/SearchSourceFactory.ts
@@ -32,7 +32,9 @@ export function SearchSourceFactory(
     input: string,
     callback: (results: SearchResult[]) => void
   ): void {
-    const rawTokens = tokenize(input);
+    // allow for the value to exist in a string
+    const rawTokens = tokenize(`*${input}`);
+
     if (rawTokens.length === 0) {
       callback([]);
       onResults(input, []);
@@ -43,6 +45,7 @@ export function SearchSourceFactory(
       removeDefaultStopWordFilter,
     });
 
+    console.log(queries);
     const results: InitialSearchResult[] = [];
 
     search: for (const { term, tokens } of queries) {

--- a/src/client/utils/SearchSourceFactory.ts
+++ b/src/client/utils/SearchSourceFactory.ts
@@ -45,7 +45,6 @@ export function SearchSourceFactory(
       removeDefaultStopWordFilter,
     });
 
-    console.log(queries);
     const results: InitialSearchResult[] = [];
 
     search: for (const { term, tokens } of queries) {

--- a/src/server/utils/tokenizer.ts
+++ b/src/server/utils/tokenizer.ts
@@ -23,6 +23,7 @@ export function tokenizer(
   let start = 0;
   let text = content;
   while (text.length > 0) {
+    console.log(text);
     const match = text.match(/\w+/u);
     if (!match) {
       break;

--- a/src/server/utils/tokenizer.ts
+++ b/src/server/utils/tokenizer.ts
@@ -23,7 +23,6 @@ export function tokenizer(
   let start = 0;
   let text = content;
   while (text.length > 0) {
-    console.log(text);
     const match = text.match(/\w+/u);
     if (!match) {
       break;


### PR DESCRIPTION
fixes #47 

# Summary

we were only allowing the string to be a full match. Now we allow the string to exist in any part of any resulting text.

## Before

<img width="1518" alt="Screenshot 2022-10-22 at 1 56 50 PM" src="https://user-images.githubusercontent.com/1854811/197362360-1fa914f7-72ba-4a9a-b813-9ccea6a09734.png">
<img width="1518" alt="Screenshot 2022-10-22 at 1 56 46 PM" src="https://user-images.githubusercontent.com/1854811/197362362-77ef2d72-856f-40b5-a07e-d2e89e11fcbb.png">

## After

<img width="1518" alt="Screenshot 2022-10-22 at 1 56 29 PM" src="https://user-images.githubusercontent.com/1854811/197362381-d125aadd-95b8-453f-8cca-9deab8f842df.png">
<img width="1518" alt="Screenshot 2022-10-22 at 1 56 24 PM" src="https://user-images.githubusercontent.com/1854811/197362382-a1c78201-a3e2-456b-818d-039bdcc4d4bc.png">
<img width="1518" alt="Screenshot 2022-10-22 at 2 01 11 PM" src="https://user-images.githubusercontent.com/1854811/197362383-20b0367a-c53f-4f98-8292-7a8f1589f6cb.png">
<img width="1518" alt="Screenshot 2022-10-22 at 2 01 07 PM" src="https://user-images.githubusercontent.com/1854811/197362384-caee3835-f8e8-4228-9896-11390ee82b63.png">
