### PR TITLE
feat: show results with additional context

### DIFF
--- a/src/client/theme/SearchModal/SearchResult.tsx
+++ b/src/client/theme/SearchModal/SearchResult.tsx
@@ -131,6 +131,10 @@ const SearchResult: React.FC<SuggestionTemplateProps> = (props) => {
     _onClick();
   }
 
+  const { u } = document;
+
+  const url = sanitizeUrl(u);
+
   return (
     <div
       className={clsx(styles.searchResult, isHovered ? styles.cursor : "")}
@@ -170,20 +174,24 @@ const SearchResult: React.FC<SuggestionTemplateProps> = (props) => {
         {isTitle ? (
           <span className={styles.hitPath}>{document.u}</span>
         ) : (
-          <span
-            className={styles.hitPath}
-            dangerouslySetInnerHTML={{
-              __html: highlight(
-                (page as SearchDocument).t ||
-                  // Todo(weareoutman): This is for EasyOps only.
-                  // istanbul ignore next
-                  (document.u.startsWith("/docs/api-reference/")
-                    ? "API Reference"
-                    : ""),
-                tokens
-              ),
-            }}
-          />
+          <>
+            <span
+              className={styles.hitPath}
+              dangerouslySetInnerHTML={{
+                __html: highlight(
+                  (page as SearchDocument).t ||
+                    // Todo(weareoutman): This is for EasyOps only.
+                    // istanbul ignore next
+                    (document.u.startsWith("/docs/api-reference/")
+                      ? "API Reference"
+                      : ""),
+                  tokens
+                ),
+              }}
+            />
+
+            <small className={styles.urlPath}>{url}</small>
+          </>
         )}
       </span>
 

--- a/src/client/theme/SearchModal/index.module.css
+++ b/src/client/theme/SearchModal/index.module.css
@@ -1,6 +1,6 @@
 /* Variables */
 :root {
-  --search-local-result-height: 56px;
+  --search-local-result-height: 65px;
   --search-local-result-shadow: 0 1px 3px 0 rgb(212, 217, 225);
 }
 
@@ -177,7 +177,7 @@ html[data-theme="dark"] {
   color: var(--ifm-font-color-base);
   display: flex;
   flex-direction: row;
-  height: var(--search-local-result-height, 56px);
+  height: var(--search-local-result-height, 65px);
 }
 
 html[data-theme="dark"] .searchResult {
@@ -246,7 +246,7 @@ html[data-theme="dark"] .hitPath {
 }
 
 .hitTitle {
-  font-size: 0.9em;
+  font-size: 0.8em;
 }
 
 .hitPath {
@@ -263,4 +263,8 @@ html[data-theme="dark"] .hitPath {
 .hitAction {
   height: 20px;
   width: 20px;
+}
+
+.urlPath {
+  font-size: 8px;
 }

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+tags: [hello]
 ---
 
 # Getting started

--- a/website/static/search-index.json
+++ b/website/static/search-index.json
@@ -3,37 +3,49 @@
     "documents": [
       {
         "i": 1,
-        "t": "First Blog Post",
-        "u": "/docusaurus-plugin-search-local/blog/first-blog-post/",
-        "b": ["Blog"]
-      },
-      {
-        "i": 3,
-        "t": "Welcome",
-        "u": "/docusaurus-plugin-search-local/blog/welcome/",
-        "b": ["Blog"]
-      },
-      {
-        "i": 5,
-        "t": "Long Blog Post",
-        "u": "/docusaurus-plugin-search-local/blog/long-blog-post/",
-        "b": ["Blog"]
-      },
-      {
-        "i": 7,
-        "t": "MDX Blog Post",
-        "u": "/docusaurus-plugin-search-local/blog/mdx-blog-post/",
-        "b": ["Blog"]
-      },
-      {
-        "i": 9,
         "t": "",
         "u": "/docusaurus-plugin-search-local/blog/archive/",
         "b": ["Blog"]
       },
       {
+        "i": 2,
+        "t": "First Blog Post",
+        "u": "/docusaurus-plugin-search-local/blog/first-blog-post/",
+        "b": ["Blog"]
+      },
+      {
+        "i": 4,
+        "t": "MDX Blog Post",
+        "u": "/docusaurus-plugin-search-local/blog/mdx-blog-post/",
+        "b": ["Blog"]
+      },
+      {
+        "i": 6,
+        "t": "Long Blog Post",
+        "u": "/docusaurus-plugin-search-local/blog/long-blog-post/",
+        "b": ["Blog"]
+      },
+      {
+        "i": 8,
+        "t": "Welcome",
+        "u": "/docusaurus-plugin-search-local/blog/welcome/",
+        "b": ["Blog"]
+      },
+      {
         "i": 10,
-        "t": "Getting started",
+        "t": "",
+        "u": "/docusaurus-plugin-search-local/docs/tags/",
+        "b": []
+      },
+      {
+        "i": 13,
+        "t": "",
+        "u": "/docusaurus-plugin-search-local/docs/tags/hello/",
+        "b": []
+      },
+      {
+        "i": 15,
+        "t": "",
         "u": "/docusaurus-plugin-search-local/docs/getting-started/",
         "b": ["Documentation"]
       }
@@ -42,12 +54,14 @@
       "version": "2.3.9",
       "fields": ["t"],
       "fieldVectors": [
-        ["t/1", [0, 1.279, 1, 0.575, 2, 0.575]],
-        ["t/3", [3, 1.937]],
-        ["t/5", [1, 0.575, 2, 0.575, 4, 1.279]],
-        ["t/7", [1, 0.575, 2, 0.575, 5, 1.279]],
-        ["t/9", []],
-        ["t/10", [6, 1.54, 7, 1.54]]
+        ["t/1", []],
+        ["t/2", [0, 1.139, 1, 0.601, 2, 0.601]],
+        ["t/4", [1, 0.601, 2, 0.601, 3, 1.139]],
+        ["t/6", [1, 0.601, 2, 0.601, 4, 1.139]],
+        ["t/8", [5, 1.951]],
+        ["t/10", []],
+        ["t/13", []],
+        ["t/15", []]
       ],
       "invertedIndex": [
         [
@@ -55,29 +69,27 @@
           {
             "_index": 1,
             "t": {
-              "1": { "position": [[6, 4]] },
-              "5": { "position": [[5, 4]] },
-              "7": { "position": [[4, 4]] }
+              "2": { "position": [[6, 4]] },
+              "4": { "position": [[4, 4]] },
+              "6": { "position": [[5, 4]] }
             }
           }
         ],
-        ["first", { "_index": 0, "t": { "1": { "position": [[0, 5]] } } }],
-        ["get", { "_index": 6, "t": { "10": { "position": [[0, 7]] } } }],
-        ["long", { "_index": 4, "t": { "5": { "position": [[0, 4]] } } }],
-        ["mdx", { "_index": 5, "t": { "7": { "position": [[0, 3]] } } }],
+        ["first", { "_index": 0, "t": { "2": { "position": [[0, 5]] } } }],
+        ["long", { "_index": 4, "t": { "6": { "position": [[0, 4]] } } }],
+        ["mdx", { "_index": 3, "t": { "4": { "position": [[0, 3]] } } }],
         [
           "post",
           {
             "_index": 2,
             "t": {
-              "1": { "position": [[11, 4]] },
-              "5": { "position": [[10, 4]] },
-              "7": { "position": [[9, 4]] }
+              "2": { "position": [[11, 4]] },
+              "4": { "position": [[9, 4]] },
+              "6": { "position": [[10, 4]] }
             }
           }
         ],
-        ["start", { "_index": 7, "t": { "10": { "position": [[8, 7]] } } }],
-        ["welcom", { "_index": 3, "t": { "3": { "position": [[0, 7]] } } }]
+        ["welcom", { "_index": 5, "t": { "8": { "position": [[0, 7]] } } }]
       ],
       "pipeline": ["stemmer"]
     }
@@ -85,39 +97,84 @@
   {
     "documents": [
       {
-        "i": 12,
-        "t": "Installation",
-        "u": "/docusaurus-plugin-search-local/docs/getting-started/",
-        "h": "#installation",
+        "i": 11,
+        "t": "H",
+        "u": "/docusaurus-plugin-search-local/docs/tags/",
+        "h": "",
         "p": 10
       },
       {
         "i": 14,
-        "t": "Configuration",
-        "u": "/docusaurus-plugin-search-local/docs/getting-started/",
-        "h": "#configuration",
-        "p": 10
+        "t": "Getting started",
+        "u": "/docusaurus-plugin-search-local/docs/tags/hello/",
+        "h": "",
+        "p": 13
       },
       {
         "i": 16,
+        "t": "Getting started",
+        "u": "/docusaurus-plugin-search-local/docs/getting-started/",
+        "h": "",
+        "p": 15
+      },
+      {
+        "i": 18,
+        "t": "Installation",
+        "u": "/docusaurus-plugin-search-local/docs/getting-started/",
+        "h": "#installation",
+        "p": 15
+      },
+      {
+        "i": 20,
+        "t": "Configuration",
+        "u": "/docusaurus-plugin-search-local/docs/getting-started/",
+        "h": "#configuration",
+        "p": 15
+      },
+      {
+        "i": 22,
         "t": "Options",
         "u": "/docusaurus-plugin-search-local/docs/getting-started/",
         "h": "#options",
-        "p": 10
+        "p": 15
       }
     ],
     "index": {
       "version": "2.3.9",
       "fields": ["t"],
       "fieldVectors": [
-        ["t/12", [0, 0.981]],
-        ["t/14", [1, 0.981]],
-        ["t/16", [2, 0.981]]
+        ["t/11", [0, 1.716]],
+        ["t/14", [1, 0.855, 2, 0.855]],
+        ["t/16", [1, 0.855, 2, 0.855]],
+        ["t/18", [3, 1.716]],
+        ["t/20", [4, 1.716]],
+        ["t/22", [5, 1.716]]
       ],
       "invertedIndex": [
-        ["configur", { "_index": 1, "t": { "14": { "position": [[0, 13]] } } }],
-        ["instal", { "_index": 0, "t": { "12": { "position": [[0, 12]] } } }],
-        ["option", { "_index": 2, "t": { "16": { "position": [[0, 7]] } } }]
+        ["configur", { "_index": 4, "t": { "20": { "position": [[0, 13]] } } }],
+        [
+          "get",
+          {
+            "_index": 1,
+            "t": {
+              "14": { "position": [[0, 7]] },
+              "16": { "position": [[0, 7]] }
+            }
+          }
+        ],
+        ["h", { "_index": 0, "t": { "11": { "position": [[0, 1]] } } }],
+        ["instal", { "_index": 3, "t": { "18": { "position": [[0, 12]] } } }],
+        ["option", { "_index": 5, "t": { "22": { "position": [[0, 7]] } } }],
+        [
+          "start",
+          {
+            "_index": 2,
+            "t": {
+              "14": { "position": [[8, 7]] },
+              "16": { "position": [[8, 7]] }
+            }
+          }
+        ]
       ],
       "pipeline": ["stemmer"]
     }
@@ -125,68 +182,76 @@
   {
     "documents": [
       {
-        "i": 2,
+        "i": 3,
         "t": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet",
         "s": "First Blog Post",
         "u": "/docusaurus-plugin-search-local/blog/first-blog-post/",
         "h": "",
-        "p": 1
+        "p": 2
       },
       {
-        "i": 4,
-        "t": "Docusaurus blogging features are powered by the blog plugin. Simply add Markdown files (or folders) to the blog directory. Regular blog authors can be added to authors.yml. The blog post date can be extracted from filenames, such as: 2019-05-30-welcome.md 2019-05-30-welcome/index.md A blog post folder can be convenient to co-locate blog post images: The blog supports tags as well! And if you don't want a blog: just delete this directory, and use blog: false in your Docusaurus config.",
-        "s": "Welcome",
-        "u": "/docusaurus-plugin-search-local/blog/welcome/",
+        "i": 5,
+        "t": "Blog posts support Docusaurus Markdown features, such as MDX. tip Use the power of React to create interactive blog posts. <button onClick={() => alert('button clicked!')}>Click me!</button> Click me!",
+        "s": "MDX Blog Post",
+        "u": "/docusaurus-plugin-search-local/blog/mdx-blog-post/",
         "h": "",
-        "p": 3
+        "p": 4
       },
       {
-        "i": 6,
+        "i": 7,
         "t": "This is the summary of a very long blog post, Use a <!-- truncate --> comment to limit blog post size in the list view. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet",
         "s": "Long Blog Post",
         "u": "/docusaurus-plugin-search-local/blog/long-blog-post/",
         "h": "",
-        "p": 5
+        "p": 6
       },
       {
-        "i": 8,
-        "t": "Blog posts support Docusaurus Markdown features, such as MDX. tip Use the power of React to create interactive blog posts. <button onClick={() => alert('button clicked!')}>Click me!</button> Copy Click me!",
-        "s": "MDX Blog Post",
-        "u": "/docusaurus-plugin-search-local/blog/mdx-blog-post/",
+        "i": 9,
+        "t": "Docusaurus blogging features are powered by the blog plugin. Simply add Markdown files (or folders) to the blog directory. Regular blog authors can be added to authors.yml. The blog post date can be extracted from filenames, such as: 2019-05-30-welcome.md 2019-05-30-welcome/index.md A blog post folder can be convenient to co-locate blog post images: The blog supports tags as well! And if you don't want a blog: just delete this directory, and use blog: false in your Docusaurus config.",
+        "s": "Welcome",
+        "u": "/docusaurus-plugin-search-local/blog/welcome/",
         "h": "",
-        "p": 7
+        "p": 8
       },
       {
-        "i": 11,
-        "t": "On this page",
-        "s": "Getting started",
-        "u": "/docusaurus-plugin-search-local/docs/getting-started/",
+        "i": 12,
+        "t": "hello1",
+        "s": "H",
+        "u": "/docusaurus-plugin-search-local/docs/tags/",
         "h": "",
-        "p": 10
-      },
-      {
-        "i": 13,
-        "t": "yarn install docusaurus-plugin-search-local Copy",
-        "s": "Installation",
-        "u": "/docusaurus-plugin-search-local/docs/getting-started/",
-        "h": "#installation",
-        "p": 10
-      },
-      {
-        "i": 15,
-        "t": "docusaurus.config.js { plugins: [ [ require.resolve(\"docusaurus-plugin-search-local\"), { ...options }, ], ],} Copy",
-        "s": "Configuration",
-        "u": "/docusaurus-plugin-search-local/docs/getting-started/",
-        "h": "#configuration",
         "p": 10
       },
       {
         "i": 17,
+        "t": "Let's discover how to install and configure docusaurus-plugin-search-local",
+        "s": "Getting started",
+        "u": "/docusaurus-plugin-search-local/docs/getting-started/",
+        "h": "",
+        "p": 15
+      },
+      {
+        "i": 19,
+        "t": "yarn install docusaurus-plugin-search-local",
+        "s": "Installation",
+        "u": "/docusaurus-plugin-search-local/docs/getting-started/",
+        "h": "#installation",
+        "p": 15
+      },
+      {
+        "i": 21,
+        "t": "docusaurus.config.js { plugins: [ [ require.resolve(\"docusaurus-plugin-search-local\"), { ...options }, ], ],}",
+        "s": "Configuration",
+        "u": "/docusaurus-plugin-search-local/docs/getting-started/",
+        "h": "#configuration",
+        "p": 15
+      },
+      {
+        "i": 23,
         "t": "Name Type Default Description indexDocs boolean true Whether to index docs. indexBlog boolean true Whether to index blog. indexPages boolean false Whether to index pages. docsRouteBasePath string | string[] \"/docs\" Base route path(s) of docs. Slash at beginning is not required. blogRouteBasePath string | string[] \"/blog\" Base route path(s) of blog. Slash at beginning is not required. language string | string[] \"en\" All lunr-languages supported languages, + zh 🔥. hashed boolean false Whether to add a hashed query when fetching index (based on the content hash of all indexed *.md in docsDir and blogDir if applicable) docsDir string | string[] \"docs\" The dir(s) of docs to get the content hash, it's relative to the dir of your project. blogDir string | string[] \"blog\" Just like the docsDir but applied to blog. removeDefaultStopWordFilter boolean false Sometimes people (E.g., us) want to keep the English stop words as indexed, since they maybe are relevant in programming docs. highlightSearchTermsOnTargetPage boolean false Highlight search terms on target page. searchResultLimits number 8 Limit the search results. searchResultContextMaxLength number 50 Set the max length of characters of each search result to show. translations TranslationMap - Set translations of this plugin, see docs below. ignoreFiles string | RegExp | (string | RegExp)[] /meta\\$/ Set the match rules to ignore some files.",
         "s": "Options",
         "u": "/docusaurus-plugin-search-local/docs/getting-started/",
         "h": "#options",
-        "p": 10
+        "p": 15
       }
     ],
     "index": {
@@ -194,77 +259,83 @@
       "fields": ["t"],
       "fieldVectors": [
         [
-          "t/2",
+          "t/3",
           [
-            0, 2.208, 1, 2.38, 2, 2.208, 3, 2.208, 4, 2.208, 5, 1.815, 6, 1.815,
-            7, 1.815, 8, 1.815, 9, 1.815, 10, 1.815, 11, 1.815, 12, 1.815, 13,
-            1.815, 14, 1.815, 15, 1.815, 16, 1.815, 17, 1.815
+            0, 2.363, 1, 2.554, 2, 2.363, 3, 2.363, 4, 2.363, 5, 1.928, 6,
+            1.928, 7, 1.928, 8, 1.928, 9, 1.928, 10, 1.928, 11, 1.928, 12,
+            1.928, 13, 1.928, 14, 1.928, 15, 1.928, 16, 1.928, 17, 1.928
           ]
         ],
         [
-          "t/4",
+          "t/5",
           [
-            18, 1.444, 19, 1.402, 20, 1.5, 21, 1.5, 22, 0.812, 23, 2.099, 24,
-            1.5, 25, 1.5, 26, 1.5, 27, 2.739, 28, 2.739, 29, 2.099, 30, 2.099,
-            31, 2.099, 32, 2.099, 33, 1.607, 34, 2.099, 35, 2.099, 36, 2.099,
-            37, 1.5, 38, 2.739, 39, 2.739, 40, 2.739, 41, 2.099, 42, 2.099, 43,
-            2.099, 44, 2.099, 45, 2.099, 46, 2.099, 47, 1.106, 48, 2.099, 49,
-            2.099, 50, 2.099, 51, 1.5, 52, 2.099, 53, 1.106, 54, 1.5, 55, 2.099
+            18, 1.367, 19, 1.797, 20, 1.471, 21, 1.119, 22, 1.943, 23, 1.943,
+            24, 1.943, 25, 2.658, 26, 2.658, 27, 1.471, 28, 1.943, 29, 2.658,
+            30, 2.658, 31, 2.658, 32, 2.658, 33, 2.658, 34, 1.119, 35, 2.658,
+            36, 2.658, 37, 2.658, 38, 2.658
           ]
         ],
         [
-          "t/6",
+          "t/7",
           [
-            0, 2.47, 1, 2.576, 2, 2.47, 3, 2.47, 4, 2.47, 5, 2.199, 6, 2.199, 7,
-            2.199, 8, 2.199, 9, 2.199, 10, 2.199, 11, 2.199, 12, 2.199, 13,
-            2.199, 14, 2.199, 15, 2.199, 16, 2.199, 17, 2.199, 19, 0.469, 33,
-            0.639, 53, 0.377, 56, 0.716, 57, 0.716, 58, 0.716, 59, 0.469, 60,
-            0.716, 61, 0.716, 62, 0.512, 63, 0.716, 64, 0.716, 65, 0.716
+            0, 2.638, 1, 2.762, 2, 2.638, 3, 2.638, 4, 2.638, 5, 2.324, 6,
+            2.324, 7, 2.324, 8, 2.324, 9, 2.324, 10, 2.324, 11, 2.324, 12,
+            2.324, 13, 2.324, 14, 2.324, 15, 2.324, 16, 2.324, 17, 2.324, 18,
+            0.502, 19, 0.66, 27, 0.385, 34, 0.502, 39, 0.696, 40, 0.696, 41,
+            0.696, 42, 0.696, 43, 0.696, 44, 0.509, 45, 0.696, 46, 0.696, 47,
+            0.696
           ]
         ],
         [
-          "t/8",
+          "t/9",
           [
-            18, 1.339, 19, 1.195, 20, 1.815, 21, 1.815, 25, 1.815, 33, 1.628,
-            37, 1.815, 47, 1.339, 53, 1.339, 59, 0.982, 66, 2.539, 67, 2.539,
-            68, 2.539, 69, 2.539, 70, 2.539, 71, 2.539, 72, 2.539, 73, 2.539,
-            74, 2.539, 75, 2.539, 76, 1.339, 77, 2.539
+            18, 1.605, 19, 1.756, 20, 1.187, 21, 1.193, 22, 1.568, 23, 1.568,
+            24, 1.568, 27, 1.187, 28, 1.568, 48, 0.676, 49, 2.145, 50, 1.568,
+            51, 1.568, 52, 2.834, 53, 2.834, 54, 2.145, 55, 2.145, 56, 2.145,
+            57, 2.145, 58, 2.145, 59, 2.145, 60, 2.145, 61, 2.834, 62, 2.834,
+            63, 2.834, 64, 2.145, 65, 2.145, 66, 2.145, 67, 2.145, 68, 2.145,
+            69, 2.145, 70, 2.145, 71, 2.145, 72, 2.145, 73, 1.568, 74, 2.145,
+            75, 1.568, 76, 2.145
           ]
         ],
-        ["t/11", [78, 2.15]],
-        [
-          "t/13",
-          [
-            18, 1.513, 22, 1.11, 76, 1.513, 79, 2.87, 80, 2.87, 81, 1.513, 82,
-            2.052
-          ]
-        ],
-        [
-          "t/15",
-          [
-            22, 1.241, 59, 1.431, 76, 1.425, 81, 1.425, 82, 1.933, 83, 2.704,
-            84, 2.704, 85, 2.704
-          ]
-        ],
+        ["t/12", [77, 3.182]],
         [
           "t/17",
           [
-            19, 1.094, 22, 0.513, 24, 0.948, 26, 0.948, 47, 0.699, 51, 0.948,
-            54, 1.888, 59, 1.274, 62, 0.948, 78, 1.419, 81, 1.254, 86, 1.327,
-            87, 1.327, 88, 1.327, 89, 1.327, 90, 1.327, 91, 2.967, 92, 1.985,
-            93, 2.641, 94, 2.967, 95, 3.076, 96, 1.327, 97, 1.327, 98, 1.327,
-            99, 3.386, 100, 2.379, 101, 1.985, 102, 1.985, 103, 1.985, 104,
-            1.985, 105, 1.985, 106, 1.327, 107, 2.379, 108, 1.327, 109, 1.327,
-            110, 1.327, 111, 2.641, 112, 1.327, 113, 1.327, 114, 1.985, 115,
-            1.327, 116, 2.379, 117, 1.985, 118, 1.327, 119, 1.327, 120, 1.327,
-            121, 1.327, 122, 1.327, 123, 1.327, 124, 1.327, 125, 1.327, 126,
-            1.327, 127, 1.327, 128, 1.327, 129, 1.327, 130, 1.327, 131, 1.327,
-            132, 1.327, 133, 1.327, 134, 1.327, 135, 1.327, 136, 1.327, 137,
-            1.327, 138, 1.327, 139, 1.327, 140, 1.327, 141, 1.985, 142, 1.327,
-            143, 1.985, 144, 1.327, 145, 1.327, 146, 2.379, 147, 1.327, 148,
-            1.327, 149, 1.327, 150, 1.327, 151, 1.327, 152, 1.985, 153, 1.327,
-            154, 1.327, 155, 1.327, 156, 1.327, 157, 1.985, 158, 1.327, 159,
-            1.327, 160, 1.327, 161, 1.327
+            21, 1.26, 48, 0.944, 78, 2.994, 79, 2.994, 80, 2.188, 81, 2.994, 82,
+            1.26, 83, 1.657
+          ]
+        ],
+        [
+          "t/19",
+          [21, 1.282, 48, 0.96, 80, 2.225, 82, 1.282, 83, 1.685, 84, 3.046]
+        ],
+        [
+          "t/21",
+          [
+            34, 1.647, 48, 1.067, 82, 1.2, 83, 1.577, 85, 2.85, 86, 2.85, 87,
+            2.85
+          ]
+        ],
+        [
+          "t/23",
+          [
+            18, 1.226, 20, 0.729, 34, 1.444, 44, 0.963, 48, 0.415, 50, 0.963,
+            51, 0.963, 73, 0.963, 75, 1.978, 82, 1.02, 88, 1.318, 89, 1.318, 90,
+            1.318, 91, 1.318, 92, 1.318, 93, 3.066, 94, 2.003, 95, 2.707, 96,
+            3.066, 97, 3.187, 98, 1.318, 99, 1.318, 100, 2.003, 101, 1.318, 102,
+            3.535, 103, 2.423, 104, 2.003, 105, 2.003, 106, 2.003, 107, 2.003,
+            108, 2.003, 109, 1.318, 110, 2.423, 111, 1.318, 112, 1.318, 113,
+            1.318, 114, 2.707, 115, 1.318, 116, 1.318, 117, 2.003, 118, 1.318,
+            119, 2.423, 120, 2.003, 121, 1.318, 122, 1.318, 123, 1.318, 124,
+            1.318, 125, 1.318, 126, 1.318, 127, 1.318, 128, 1.318, 129, 1.318,
+            130, 1.318, 131, 1.318, 132, 1.318, 133, 1.318, 134, 1.318, 135,
+            1.318, 136, 1.318, 137, 1.318, 138, 1.318, 139, 1.318, 140, 1.318,
+            141, 1.318, 142, 1.318, 143, 1.318, 144, 2.003, 145, 1.318, 146,
+            2.003, 147, 1.318, 148, 1.318, 149, 2.423, 150, 1.318, 151, 1.318,
+            152, 1.318, 153, 1.318, 154, 1.318, 155, 2.003, 156, 1.318, 157,
+            1.318, 158, 1.318, 159, 1.318, 160, 2.003, 161, 1.318, 162, 1.318,
+            163, 1.318, 164, 1.318
           ]
         ]
       ],
@@ -272,16 +343,16 @@
         [
           "",
           {
-            "_index": 59,
+            "_index": 34,
             "t": {
-              "6": {
+              "5": { "position": [[143, 2]] },
+              "7": {
                 "position": [
                   [52, 2],
                   [68, 1]
                 ]
               },
-              "8": { "position": [[143, 2]] },
-              "15": {
+              "21": {
                 "position": [
                   [21, 1],
                   [32, 1],
@@ -292,7 +363,7 @@
                   [106, 3]
                 ]
               },
-              "17": {
+              "23": {
                 "position": [
                   [196, 1],
                   [304, 1],
@@ -312,9 +383,9 @@
         [
           "05",
           {
-            "_index": 39,
+            "_index": 62,
             "t": {
-              "4": {
+              "9": {
                 "position": [
                   [239, 2],
                   [261, 2]
@@ -326,9 +397,9 @@
         [
           "2019",
           {
-            "_index": 38,
+            "_index": 61,
             "t": {
-              "4": {
+              "9": {
                 "position": [
                   [234, 4],
                   [256, 4]
@@ -340,9 +411,9 @@
         [
           "30",
           {
-            "_index": 40,
+            "_index": 63,
             "t": {
-              "4": {
+              "9": {
                 "position": [
                   [242, 2],
                   [264, 2]
@@ -351,16 +422,16 @@
             }
           }
         ],
-        ["50", { "_index": 145, "t": { "17": { "position": [[1164, 2]] } } }],
-        ["8", { "_index": 142, "t": { "17": { "position": [[1100, 1]] } } }],
-        ["ad", { "_index": 31, "t": { "4": { "position": [[151, 5]] } } }],
+        ["50", { "_index": 148, "t": { "23": { "position": [[1164, 2]] } } }],
+        ["8", { "_index": 145, "t": { "23": { "position": [[1100, 1]] } } }],
+        ["ad", { "_index": 56, "t": { "9": { "position": [[151, 5]] } } }],
         [
           "add",
           {
-            "_index": 24,
+            "_index": 50,
             "t": {
-              "4": { "position": [[68, 3]] },
-              "17": { "position": [[500, 3]] }
+              "9": { "position": [[68, 3]] },
+              "23": { "position": [[500, 3]] }
             }
           }
         ],
@@ -369,8 +440,8 @@
           {
             "_index": 6,
             "t": {
-              "2": { "position": [[40, 10]] },
-              "6": {
+              "3": { "position": [[40, 10]] },
+              "7": {
                 "position": [
                   [160, 10],
                   [339, 10],
@@ -395,15 +466,15 @@
         ],
         [
           "alert('button",
-          { "_index": 73, "t": { "8": { "position": [[146, 13]] } } }
+          { "_index": 35, "t": { "5": { "position": [[146, 13]] } } }
         ],
         [
           "aliquam",
           {
             "_index": 16,
             "t": {
-              "2": { "position": [[133, 7]] },
-              "6": {
+              "3": { "position": [[133, 7]] },
+              "7": {
                 "position": [
                   [253, 7],
                   [432, 7],
@@ -431,13 +502,13 @@
           {
             "_index": 4,
             "t": {
-              "2": {
+              "3": {
                 "position": [
                   [22, 5],
                   [174, 4]
                 ]
               },
-              "6": {
+              "7": {
                 "position": [
                   [142, 5],
                   [294, 4],
@@ -476,22 +547,22 @@
             }
           }
         ],
-        ["appli", { "_index": 124, "t": { "17": { "position": [[802, 7]] } } }],
+        ["appli", { "_index": 127, "t": { "23": { "position": [[802, 7]] } } }],
         [
           "applic",
-          { "_index": 118, "t": { "17": { "position": [[612, 11]] } } }
+          { "_index": 121, "t": { "23": { "position": [[612, 11]] } } }
         ],
-        ["author", { "_index": 30, "t": { "4": { "position": [[136, 7]] } } }],
+        ["author", { "_index": 55, "t": { "9": { "position": [[136, 7]] } } }],
         [
           "authors.yml",
-          { "_index": 32, "t": { "4": { "position": [[160, 12]] } } }
+          { "_index": 57, "t": { "9": { "position": [[160, 12]] } } }
         ],
         [
           "base",
           {
-            "_index": 100,
+            "_index": 103,
             "t": {
-              "17": {
+              "23": {
                 "position": [
                   [215, 4],
                   [323, 4],
@@ -504,9 +575,9 @@
         [
           "begin",
           {
-            "_index": 104,
+            "_index": 107,
             "t": {
-              "17": {
+              "23": {
                 "position": [
                   [252, 9],
                   [360, 9]
@@ -517,14 +588,26 @@
         ],
         [
           "below",
-          { "_index": 155, "t": { "17": { "position": [[1303, 6]] } } }
+          { "_index": 158, "t": { "23": { "position": [[1303, 6]] } } }
         ],
         [
           "blog",
           {
-            "_index": 19,
+            "_index": 18,
             "t": {
-              "4": {
+              "5": {
+                "position": [
+                  [0, 4],
+                  [111, 4]
+                ]
+              },
+              "7": {
+                "position": [
+                  [35, 4],
+                  [87, 4]
+                ]
+              },
+              "9": {
                 "position": [
                   [11, 8],
                   [48, 4],
@@ -538,19 +621,7 @@
                   [450, 5]
                 ]
               },
-              "6": {
-                "position": [
-                  [35, 4],
-                  [87, 4]
-                ]
-              },
-              "8": {
-                "position": [
-                  [0, 4],
-                  [111, 4]
-                ]
-              },
-              "17": {
+              "23": {
                 "position": [
                   [116, 5],
                   [315, 7],
@@ -565,9 +636,9 @@
         [
           "blogdir",
           {
-            "_index": 117,
+            "_index": 120,
             "t": {
-              "17": {
+              "23": {
                 "position": [
                   [601, 7],
                   [743, 7]
@@ -578,14 +649,14 @@
         ],
         [
           "blogroutebasepath",
-          { "_index": 106, "t": { "17": { "position": [[279, 17]] } } }
+          { "_index": 109, "t": { "23": { "position": [[279, 17]] } } }
         ],
         [
           "boolean",
           {
-            "_index": 91,
+            "_index": 93,
             "t": {
-              "17": {
+              "23": {
                 "position": [
                   [40, 7],
                   [86, 7],
@@ -598,26 +669,30 @@
             }
           }
         ],
-        ["button", { "_index": 71, "t": { "8": { "position": [[123, 7]] } } }],
+        ["button", { "_index": 32, "t": { "5": { "position": [[123, 7]] } } }],
         [
           "charact",
-          { "_index": 149, "t": { "17": { "position": [[1189, 10]] } } }
+          { "_index": 152, "t": { "23": { "position": [[1189, 10]] } } }
         ],
-        ["click", { "_index": 77, "t": { "8": { "position": [[196, 5]] } } }],
+        ["click", { "_index": 38, "t": { "5": { "position": [[191, 5]] } } }],
         [
           "clicked!')}>click",
-          { "_index": 74, "t": { "8": { "position": [[160, 17]] } } }
+          { "_index": 36, "t": { "5": { "position": [[160, 17]] } } }
         ],
-        ["co", { "_index": 44, "t": { "4": { "position": [[324, 2]] } } }],
-        ["comment", { "_index": 61, "t": { "6": { "position": [[70, 7]] } } }],
-        ["config", { "_index": 55, "t": { "4": { "position": [[481, 7]] } } }],
+        ["co", { "_index": 67, "t": { "9": { "position": [[324, 2]] } } }],
+        ["comment", { "_index": 43, "t": { "7": { "position": [[70, 7]] } } }],
+        ["config", { "_index": 76, "t": { "9": { "position": [[481, 7]] } } }],
+        [
+          "configur",
+          { "_index": 81, "t": { "17": { "position": [[34, 9]] } } }
+        ],
         [
           "consectetur",
           {
             "_index": 5,
             "t": {
-              "2": { "position": [[28, 11]] },
-              "6": {
+              "3": { "position": [[28, 11]] },
+              "7": {
                 "position": [
                   [148, 11],
                   [327, 11],
@@ -645,8 +720,8 @@
           {
             "_index": 17,
             "t": {
-              "2": { "position": [[141, 10]] },
-              "6": {
+              "3": { "position": [[141, 10]] },
+              "7": {
                 "position": [
                   [261, 10],
                   [440, 10],
@@ -672,9 +747,9 @@
         [
           "content",
           {
-            "_index": 114,
+            "_index": 117,
             "t": {
-              "17": {
+              "23": {
                 "position": [
                   [553, 7],
                   [687, 7]
@@ -685,34 +760,23 @@
         ],
         [
           "conveni",
-          { "_index": 43, "t": { "4": { "position": [[310, 10]] } } }
+          { "_index": 66, "t": { "9": { "position": [[310, 10]] } } }
         ],
-        [
-          "copi",
-          {
-            "_index": 76,
-            "t": {
-              "8": { "position": [[191, 4]] },
-              "13": { "position": [[44, 4]] },
-              "15": { "position": [[110, 4]] }
-            }
-          }
-        ],
-        ["creat", { "_index": 69, "t": { "8": { "position": [[92, 6]] } } }],
-        ["date", { "_index": 34, "t": { "4": { "position": [[187, 4]] } } }],
-        ["default", { "_index": 88, "t": { "17": { "position": [[10, 7]] } } }],
-        ["delet", { "_index": 52, "t": { "4": { "position": [[419, 6]] } } }],
+        ["creat", { "_index": 30, "t": { "5": { "position": [[92, 6]] } } }],
+        ["date", { "_index": 58, "t": { "9": { "position": [[187, 4]] } } }],
+        ["default", { "_index": 90, "t": { "23": { "position": [[10, 7]] } } }],
+        ["delet", { "_index": 74, "t": { "9": { "position": [[419, 6]] } } }],
         [
           "descript",
-          { "_index": 89, "t": { "17": { "position": [[18, 11]] } } }
+          { "_index": 91, "t": { "23": { "position": [[18, 11]] } } }
         ],
         [
           "dignissim",
           {
             "_index": 10,
             "t": {
-              "2": { "position": [[80, 9]] },
-              "6": {
+              "3": { "position": [[80, 9]] },
+              "7": {
                 "position": [
                   [200, 9],
                   [379, 9],
@@ -735,14 +799,14 @@
             }
           }
         ],
-        ["dir", { "_index": 122, "t": { "17": { "position": [[722, 3]] } } }],
-        ["dir(", { "_index": 119, "t": { "17": { "position": [[661, 6]] } } }],
+        ["dir", { "_index": 125, "t": { "23": { "position": [[722, 3]] } } }],
+        ["dir(", { "_index": 122, "t": { "23": { "position": [[661, 6]] } } }],
         [
           "directori",
           {
-            "_index": 28,
+            "_index": 53,
             "t": {
-              "4": {
+              "9": {
                 "position": [
                   [112, 10],
                   [431, 10]
@@ -751,12 +815,13 @@
             }
           }
         ],
+        ["discov", { "_index": 79, "t": { "17": { "position": [[6, 8]] } } }],
         [
           "doc",
           {
-            "_index": 95,
+            "_index": 97,
             "t": {
-              "17": {
+              "23": {
                 "position": [
                   [70, 5],
                   [207, 7],
@@ -773,9 +838,9 @@
         [
           "docsdir",
           {
-            "_index": 116,
+            "_index": 119,
             "t": {
-              "17": {
+              "23": {
                 "position": [
                   [589, 7],
                   [624, 7],
@@ -787,40 +852,41 @@
         ],
         [
           "docsroutebasepath",
-          { "_index": 98, "t": { "17": { "position": [[171, 17]] } } }
+          { "_index": 101, "t": { "23": { "position": [[171, 17]] } } }
         ],
         [
           "docusauru",
           {
-            "_index": 18,
+            "_index": 21,
             "t": {
-              "4": {
+              "5": { "position": [[19, 10]] },
+              "9": {
                 "position": [
                   [0, 10],
                   [470, 10]
                 ]
               },
-              "8": { "position": [[19, 10]] },
-              "13": { "position": [[13, 10]] }
+              "17": { "position": [[44, 10]] },
+              "19": { "position": [[13, 10]] }
             }
           }
         ],
         [
           "docusaurus.config.j",
-          { "_index": 83, "t": { "15": { "position": [[0, 20]] } } }
+          { "_index": 85, "t": { "21": { "position": [[0, 20]] } } }
         ],
         [
           "dolor",
           {
             "_index": 2,
             "t": {
-              "2": {
+              "3": {
                 "position": [
                   [12, 5],
                   [164, 5]
                 ]
               },
-              "6": {
+              "7": {
                 "position": [
                   [132, 5],
                   [284, 5],
@@ -859,16 +925,16 @@
             }
           }
         ],
-        ["don't", { "_index": 50, "t": { "4": { "position": [[395, 5]] } } }],
-        ["e.g", { "_index": 128, "t": { "17": { "position": [[878, 6]] } } }],
-        ["each", { "_index": 150, "t": { "17": { "position": [[1203, 4]] } } }],
+        ["don't", { "_index": 72, "t": { "9": { "position": [[395, 5]] } } }],
+        ["e.g", { "_index": 131, "t": { "23": { "position": [[878, 6]] } } }],
+        ["each", { "_index": 153, "t": { "23": { "position": [[1203, 4]] } } }],
         [
           "elementum",
           {
             "_index": 9,
             "t": {
-              "2": { "position": [[70, 9]] },
-              "6": {
+              "3": { "position": [[70, 9]] },
+              "7": {
                 "position": [
                   [190, 9],
                   [369, 9],
@@ -896,8 +962,8 @@
           {
             "_index": 7,
             "t": {
-              "2": { "position": [[51, 5]] },
-              "6": {
+              "3": { "position": [[51, 5]] },
+              "7": {
                 "position": [
                   [171, 5],
                   [350, 5],
@@ -920,18 +986,18 @@
             }
           }
         ],
-        ["en", { "_index": 108, "t": { "17": { "position": [[414, 4]] } } }],
+        ["en", { "_index": 111, "t": { "23": { "position": [[414, 4]] } } }],
         [
           "english",
-          { "_index": 130, "t": { "17": { "position": [[906, 7]] } } }
+          { "_index": 133, "t": { "23": { "position": [[906, 7]] } } }
         ],
         [
           "ero",
           {
             "_index": 15,
             "t": {
-              "2": { "position": [[128, 4]] },
-              "6": {
+              "3": { "position": [[128, 4]] },
+              "7": {
                 "position": [
                   [248, 4],
                   [427, 4],
@@ -954,14 +1020,14 @@
             }
           }
         ],
-        ["extract", { "_index": 35, "t": { "4": { "position": [[199, 9]] } } }],
+        ["extract", { "_index": 59, "t": { "9": { "position": [[199, 9]] } } }],
         [
           "fals",
           {
-            "_index": 54,
+            "_index": 75,
             "t": {
-              "4": { "position": [[456, 5]] },
-              "17": {
+              "9": { "position": [[456, 5]] },
+              "23": {
                 "position": [
                   [141, 5],
                   [483, 5],
@@ -975,34 +1041,34 @@
         [
           "featur",
           {
-            "_index": 20,
+            "_index": 23,
             "t": {
-              "4": { "position": [[20, 8]] },
-              "8": { "position": [[39, 9]] }
+              "5": { "position": [[39, 9]] },
+              "9": { "position": [[20, 8]] }
             }
           }
         ],
-        ["fetch", { "_index": 113, "t": { "17": { "position": [[524, 8]] } } }],
+        ["fetch", { "_index": 116, "t": { "23": { "position": [[524, 8]] } } }],
         [
           "file",
           {
-            "_index": 26,
+            "_index": 51,
             "t": {
-              "4": { "position": [[81, 5]] },
-              "17": { "position": [[1404, 6]] }
+              "9": { "position": [[81, 5]] },
+              "23": { "position": [[1404, 6]] }
             }
           }
         ],
         [
           "filenam",
-          { "_index": 36, "t": { "4": { "position": [[214, 10]] } } }
+          { "_index": 60, "t": { "9": { "position": [[214, 10]] } } }
         ],
         [
           "folder",
           {
-            "_index": 27,
+            "_index": 52,
             "t": {
-              "4": {
+              "9": {
                 "position": [
                   [91, 8],
                   [296, 6]
@@ -1016,8 +1082,8 @@
           {
             "_index": 12,
             "t": {
-              "2": { "position": [[101, 5]] },
-              "6": {
+              "3": { "position": [[101, 5]] },
+              "7": {
                 "position": [
                   [221, 5],
                   [400, 5],
@@ -1043,9 +1109,9 @@
         [
           "hash",
           {
-            "_index": 111,
+            "_index": 114,
             "t": {
-              "17": {
+              "23": {
                 "position": [
                   [468, 6],
                   [506, 6],
@@ -1056,29 +1122,30 @@
             }
           }
         ],
+        ["hello1", { "_index": 77, "t": { "12": { "position": [[0, 6]] } } }],
         [
           "highlight",
-          { "_index": 137, "t": { "17": { "position": [[1035, 9]] } } }
+          { "_index": 140, "t": { "23": { "position": [[1035, 9]] } } }
         ],
         [
           "highlightsearchtermsontargetpag",
-          { "_index": 136, "t": { "17": { "position": [[988, 32]] } } }
+          { "_index": 139, "t": { "23": { "position": [[988, 32]] } } }
         ],
         [
           "ignor",
-          { "_index": 161, "t": { "17": { "position": [[1392, 6]] } } }
+          { "_index": 164, "t": { "23": { "position": [[1392, 6]] } } }
         ],
         [
           "ignorefil",
-          { "_index": 156, "t": { "17": { "position": [[1310, 11]] } } }
+          { "_index": 159, "t": { "23": { "position": [[1310, 11]] } } }
         ],
-        ["imag", { "_index": 46, "t": { "4": { "position": [[344, 7]] } } }],
+        ["imag", { "_index": 69, "t": { "9": { "position": [[344, 7]] } } }],
         [
           "index",
           {
-            "_index": 94,
+            "_index": 96,
             "t": {
-              "17": {
+              "23": {
                 "position": [
                   [64, 5],
                   [110, 5],
@@ -1093,34 +1160,43 @@
         ],
         [
           "indexblog",
-          { "_index": 96, "t": { "17": { "position": [[76, 9]] } } }
+          { "_index": 98, "t": { "23": { "position": [[76, 9]] } } }
         ],
         [
           "indexdoc",
-          { "_index": 90, "t": { "17": { "position": [[30, 9]] } } }
+          { "_index": 92, "t": { "23": { "position": [[30, 9]] } } }
         ],
         [
           "indexpag",
-          { "_index": 97, "t": { "17": { "position": [[122, 10]] } } }
+          { "_index": 99, "t": { "23": { "position": [[122, 10]] } } }
         ],
-        ["instal", { "_index": 80, "t": { "13": { "position": [[5, 7]] } } }],
+        [
+          "instal",
+          {
+            "_index": 80,
+            "t": {
+              "17": { "position": [[22, 7]] },
+              "19": { "position": [[5, 7]] }
+            }
+          }
+        ],
         [
           "interact",
-          { "_index": 70, "t": { "8": { "position": [[99, 11]] } } }
+          { "_index": 31, "t": { "5": { "position": [[99, 11]] } } }
         ],
         [
           "ipsum",
           {
             "_index": 1,
             "t": {
-              "2": {
+              "3": {
                 "position": [
                   [6, 5],
                   [115, 5],
                   [158, 5]
                 ]
               },
-              "6": {
+              "7": {
                 "position": [
                   [126, 5],
                   [235, 5],
@@ -1175,14 +1251,14 @@
             }
           }
         ],
-        ["it'", { "_index": 120, "t": { "17": { "position": [[701, 4]] } } }],
-        ["keep", { "_index": 129, "t": { "17": { "position": [[897, 4]] } } }],
+        ["it'", { "_index": 123, "t": { "23": { "position": [[701, 4]] } } }],
+        ["keep", { "_index": 132, "t": { "23": { "position": [[897, 4]] } } }],
         [
           "languag",
           {
-            "_index": 107,
+            "_index": 110,
             "t": {
-              "17": {
+              "23": {
                 "position": [
                   [387, 8],
                   [428, 9],
@@ -1194,43 +1270,45 @@
         ],
         [
           "length",
-          { "_index": 148, "t": { "17": { "position": [[1179, 6]] } } }
+          { "_index": 151, "t": { "23": { "position": [[1179, 6]] } } }
         ],
+        ["let'", { "_index": 78, "t": { "17": { "position": [[0, 5]] } } }],
         [
           "limit",
           {
-            "_index": 62,
+            "_index": 44,
             "t": {
-              "6": { "position": [[81, 5]] },
-              "17": { "position": [[1102, 5]] }
+              "7": { "position": [[81, 5]] },
+              "23": { "position": [[1102, 5]] }
             }
           }
         ],
-        ["list", { "_index": 64, "t": { "6": { "position": [[109, 4]] } } }],
+        ["list", { "_index": 46, "t": { "7": { "position": [[109, 4]] } } }],
         [
           "local",
           {
-            "_index": 82,
+            "_index": 83,
             "t": {
-              "13": { "position": [[38, 5]] },
-              "15": { "position": [[78, 8]] }
+              "17": { "position": [[69, 5]] },
+              "19": { "position": [[38, 5]] },
+              "21": { "position": [[78, 8]] }
             }
           }
         ],
-        ["locat", { "_index": 45, "t": { "4": { "position": [[327, 6]] } } }],
-        ["long", { "_index": 58, "t": { "6": { "position": [[30, 4]] } } }],
+        ["locat", { "_index": 68, "t": { "9": { "position": [[327, 6]] } } }],
+        ["long", { "_index": 41, "t": { "7": { "position": [[30, 4]] } } }],
         [
           "lorem",
           {
             "_index": 0,
             "t": {
-              "2": {
+              "3": {
                 "position": [
                   [0, 5],
                   [152, 5]
                 ]
               },
-              "6": {
+              "7": {
                 "position": [
                   [120, 5],
                   [272, 5],
@@ -1269,37 +1347,37 @@
             }
           }
         ],
-        ["lunr", { "_index": 109, "t": { "17": { "position": [[423, 4]] } } }],
+        ["lunr", { "_index": 112, "t": { "23": { "position": [[423, 4]] } } }],
         [
           "markdown",
           {
-            "_index": 25,
+            "_index": 22,
             "t": {
-              "4": { "position": [[72, 8]] },
-              "8": { "position": [[30, 8]] }
+              "5": { "position": [[30, 8]] },
+              "9": { "position": [[72, 8]] }
             }
           }
         ],
         [
           "match",
-          { "_index": 159, "t": { "17": { "position": [[1377, 5]] } } }
+          { "_index": 162, "t": { "23": { "position": [[1377, 5]] } } }
         ],
-        ["max", { "_index": 147, "t": { "17": { "position": [[1175, 3]] } } }],
-        ["mayb", { "_index": 133, "t": { "17": { "position": [[948, 5]] } } }],
-        ["md", { "_index": 115, "t": { "17": { "position": [[581, 4]] } } }],
-        ["mdx", { "_index": 66, "t": { "8": { "position": [[57, 4]] } } }],
+        ["max", { "_index": 150, "t": { "23": { "position": [[1175, 3]] } } }],
+        ["mayb", { "_index": 136, "t": { "23": { "position": [[948, 5]] } } }],
+        ["md", { "_index": 118, "t": { "23": { "position": [[581, 4]] } } }],
+        ["mdx", { "_index": 25, "t": { "5": { "position": [[57, 4]] } } }],
         [
           "me!</button",
-          { "_index": 75, "t": { "8": { "position": [[178, 12]] } } }
+          { "_index": 37, "t": { "5": { "position": [[178, 12]] } } }
         ],
-        ["meta", { "_index": 158, "t": { "17": { "position": [[1360, 8]] } } }],
-        ["name", { "_index": 86, "t": { "17": { "position": [[0, 4]] } } }],
+        ["meta", { "_index": 161, "t": { "23": { "position": [[1360, 8]] } } }],
+        ["name", { "_index": 88, "t": { "23": { "position": [[0, 4]] } } }],
         [
           "number",
           {
-            "_index": 141,
+            "_index": 144,
             "t": {
-              "17": {
+              "23": {
                 "position": [
                   [1093, 6],
                   [1157, 6]
@@ -1310,16 +1388,15 @@
         ],
         [
           "onclick",
-          { "_index": 72, "t": { "8": { "position": [[131, 11]] } } }
+          { "_index": 33, "t": { "5": { "position": [[131, 11]] } } }
         ],
-        ["option", { "_index": 85, "t": { "15": { "position": [[89, 10]] } } }],
+        ["option", { "_index": 87, "t": { "21": { "position": [[89, 10]] } } }],
         [
           "page",
           {
-            "_index": 78,
+            "_index": 100,
             "t": {
-              "11": { "position": [[8, 4]] },
-              "17": {
+              "23": {
                 "position": [
                   [164, 6],
                   [1068, 5]
@@ -1331,9 +1408,9 @@
         [
           "path(",
           {
-            "_index": 102,
+            "_index": 105,
             "t": {
-              "17": {
+              "23": {
                 "position": [
                   [226, 7],
                   [334, 7]
@@ -1347,8 +1424,8 @@
           {
             "_index": 8,
             "t": {
-              "2": { "position": [[57, 12]] },
-              "6": {
+              "3": { "position": [[57, 12]] },
+              "7": {
                 "position": [
                   [177, 12],
                   [356, 12],
@@ -1371,46 +1448,47 @@
             }
           }
         ],
-        ["peopl", { "_index": 127, "t": { "17": { "position": [[871, 6]] } } }],
+        ["peopl", { "_index": 130, "t": { "23": { "position": [[871, 6]] } } }],
         [
           "plugin",
           {
-            "_index": 22,
+            "_index": 48,
             "t": {
-              "4": { "position": [[53, 7]] },
-              "13": { "position": [[24, 6]] },
-              "15": {
+              "9": { "position": [[53, 7]] },
+              "17": { "position": [[55, 6]] },
+              "19": { "position": [[24, 6]] },
+              "21": {
                 "position": [
                   [23, 8],
                   [64, 6]
                 ]
               },
-              "17": { "position": [[1286, 7]] }
+              "23": { "position": [[1286, 7]] }
             }
           }
         ],
         [
           "post",
           {
-            "_index": 33,
+            "_index": 19,
             "t": {
-              "4": {
+              "5": {
                 "position": [
-                  [182, 4],
-                  [291, 4],
-                  [339, 4]
+                  [5, 5],
+                  [116, 6]
                 ]
               },
-              "6": {
+              "7": {
                 "position": [
                   [40, 5],
                   [92, 4]
                 ]
               },
-              "8": {
+              "9": {
                 "position": [
-                  [5, 5],
-                  [116, 6]
+                  [182, 4],
+                  [291, 4],
+                  [339, 4]
                 ]
               }
             }
@@ -1419,29 +1497,29 @@
         [
           "power",
           {
-            "_index": 21,
+            "_index": 28,
             "t": {
-              "4": { "position": [[33, 7]] },
-              "8": { "position": [[74, 5]] }
+              "5": { "position": [[74, 5]] },
+              "9": { "position": [[33, 7]] }
             }
           }
         ],
         [
           "program",
-          { "_index": 135, "t": { "17": { "position": [[970, 11]] } } }
+          { "_index": 138, "t": { "23": { "position": [[970, 11]] } } }
         ],
         [
           "project",
-          { "_index": 123, "t": { "17": { "position": [[734, 8]] } } }
+          { "_index": 126, "t": { "23": { "position": [[734, 8]] } } }
         ],
-        ["queri", { "_index": 112, "t": { "17": { "position": [[513, 5]] } } }],
-        ["react", { "_index": 68, "t": { "8": { "position": [[83, 5]] } } }],
+        ["queri", { "_index": 115, "t": { "23": { "position": [[513, 5]] } } }],
+        ["react", { "_index": 29, "t": { "5": { "position": [[83, 5]] } } }],
         [
           "regexp",
           {
-            "_index": 157,
+            "_index": 160,
             "t": {
-              "17": {
+              "23": {
                 "position": [
                   [1331, 6],
                   [1350, 9]
@@ -1450,19 +1528,19 @@
             }
           }
         ],
-        ["regular", { "_index": 29, "t": { "4": { "position": [[123, 7]] } } }],
-        ["rel", { "_index": 121, "t": { "17": { "position": [[706, 8]] } } }],
-        ["relev", { "_index": 134, "t": { "17": { "position": [[958, 8]] } } }],
+        ["regular", { "_index": 54, "t": { "9": { "position": [[123, 7]] } } }],
+        ["rel", { "_index": 124, "t": { "23": { "position": [[706, 8]] } } }],
+        ["relev", { "_index": 137, "t": { "23": { "position": [[958, 8]] } } }],
         [
           "removedefaultstopwordfilt",
-          { "_index": 125, "t": { "17": { "position": [[819, 27]] } } }
+          { "_index": 128, "t": { "23": { "position": [[819, 27]] } } }
         ],
         [
           "requir",
           {
-            "_index": 105,
+            "_index": 108,
             "t": {
-              "17": {
+              "23": {
                 "position": [
                   [269, 9],
                   [377, 9]
@@ -1473,14 +1551,14 @@
         ],
         [
           "require.resolve(\"docusauru",
-          { "_index": 84, "t": { "15": { "position": [[36, 27]] } } }
+          { "_index": 86, "t": { "21": { "position": [[36, 27]] } } }
         ],
         [
           "result",
           {
-            "_index": 143,
+            "_index": 146,
             "t": {
-              "17": {
+              "23": {
                 "position": [
                   [1119, 8],
                   [1215, 6]
@@ -1494,8 +1572,8 @@
           {
             "_index": 13,
             "t": {
-              "2": { "position": [[107, 7]] },
-              "6": {
+              "3": { "position": [[107, 7]] },
+              "7": {
                 "position": [
                   [227, 7],
                   [406, 7],
@@ -1521,9 +1599,9 @@
         [
           "rout",
           {
-            "_index": 101,
+            "_index": 104,
             "t": {
-              "17": {
+              "23": {
                 "position": [
                   [220, 5],
                   [328, 5]
@@ -1532,15 +1610,16 @@
             }
           }
         ],
-        ["rule", { "_index": 160, "t": { "17": { "position": [[1383, 5]] } } }],
+        ["rule", { "_index": 163, "t": { "23": { "position": [[1383, 5]] } } }],
         [
           "search",
           {
-            "_index": 81,
+            "_index": 82,
             "t": {
-              "13": { "position": [[31, 6]] },
-              "15": { "position": [[71, 6]] },
-              "17": {
+              "17": { "position": [[62, 6]] },
+              "19": { "position": [[31, 6]] },
+              "21": { "position": [[71, 6]] },
+              "23": {
                 "position": [
                   [1045, 6],
                   [1112, 6],
@@ -1552,19 +1631,19 @@
         ],
         [
           "searchresultcontextmaxlength",
-          { "_index": 144, "t": { "17": { "position": [[1128, 28]] } } }
+          { "_index": 147, "t": { "23": { "position": [[1128, 28]] } } }
         ],
         [
           "searchresultlimit",
-          { "_index": 140, "t": { "17": { "position": [[1074, 18]] } } }
+          { "_index": 143, "t": { "23": { "position": [[1074, 18]] } } }
         ],
-        ["see", { "_index": 154, "t": { "17": { "position": [[1294, 3]] } } }],
+        ["see", { "_index": 157, "t": { "23": { "position": [[1294, 3]] } } }],
         [
           "set",
           {
-            "_index": 146,
+            "_index": 149,
             "t": {
-              "17": {
+              "23": {
                 "position": [
                   [1167, 3],
                   [1261, 3],
@@ -1574,20 +1653,20 @@
             }
           }
         ],
-        ["show", { "_index": 151, "t": { "17": { "position": [[1225, 5]] } } }],
-        ["simpli", { "_index": 23, "t": { "4": { "position": [[61, 6]] } } }],
+        ["show", { "_index": 154, "t": { "23": { "position": [[1225, 5]] } } }],
+        ["simpli", { "_index": 49, "t": { "9": { "position": [[61, 6]] } } }],
         [
           "sit",
           {
             "_index": 3,
             "t": {
-              "2": {
+              "3": {
                 "position": [
                   [18, 3],
                   [170, 3]
                 ]
               },
-              "6": {
+              "7": {
                 "position": [
                   [138, 3],
                   [290, 3],
@@ -1626,13 +1705,13 @@
             }
           }
         ],
-        ["size", { "_index": 63, "t": { "6": { "position": [[97, 4]] } } }],
+        ["size", { "_index": 45, "t": { "7": { "position": [[97, 4]] } } }],
         [
           "slash",
           {
-            "_index": 103,
+            "_index": 106,
             "t": {
-              "17": {
+              "23": {
                 "position": [
                   [243, 5],
                   [351, 5]
@@ -1643,15 +1722,15 @@
         ],
         [
           "sometim",
-          { "_index": 126, "t": { "17": { "position": [[861, 9]] } } }
+          { "_index": 129, "t": { "23": { "position": [[861, 9]] } } }
         ],
-        ["stop", { "_index": 131, "t": { "17": { "position": [[914, 4]] } } }],
+        ["stop", { "_index": 134, "t": { "23": { "position": [[914, 4]] } } }],
         [
           "string",
           {
-            "_index": 99,
+            "_index": 102,
             "t": {
-              "17": {
+              "23": {
                 "position": [
                   [189, 6],
                   [198, 8],
@@ -1673,37 +1752,37 @@
         [
           "such",
           {
-            "_index": 37,
+            "_index": 24,
             "t": {
-              "4": { "position": [[225, 4]] },
-              "8": { "position": [[49, 4]] }
+              "5": { "position": [[49, 4]] },
+              "9": { "position": [[225, 4]] }
             }
           }
         ],
-        ["summari", { "_index": 56, "t": { "6": { "position": [[12, 7]] } } }],
+        ["summari", { "_index": 39, "t": { "7": { "position": [[12, 7]] } } }],
         [
           "support",
           {
-            "_index": 47,
+            "_index": 20,
             "t": {
-              "4": { "position": [[361, 8]] },
-              "8": { "position": [[11, 7]] },
-              "17": { "position": [[438, 9]] }
+              "5": { "position": [[11, 7]] },
+              "9": { "position": [[361, 8]] },
+              "23": { "position": [[438, 9]] }
             }
           }
         ],
-        ["tag", { "_index": 48, "t": { "4": { "position": [[370, 4]] } } }],
+        ["tag", { "_index": 70, "t": { "9": { "position": [[370, 4]] } } }],
         [
           "target",
-          { "_index": 139, "t": { "17": { "position": [[1061, 6]] } } }
+          { "_index": 142, "t": { "23": { "position": [[1061, 6]] } } }
         ],
         [
           "tempor",
           {
             "_index": 14,
             "t": {
-              "2": { "position": [[121, 6]] },
-              "6": {
+              "3": { "position": [[121, 6]] },
+              "7": {
                 "position": [
                   [241, 6],
                   [420, 6],
@@ -1726,14 +1805,14 @@
             }
           }
         ],
-        ["term", { "_index": 138, "t": { "17": { "position": [[1052, 5]] } } }],
-        ["tip", { "_index": 67, "t": { "8": { "position": [[62, 3]] } } }],
+        ["term", { "_index": 141, "t": { "23": { "position": [[1052, 5]] } } }],
+        ["tip", { "_index": 26, "t": { "5": { "position": [[62, 3]] } } }],
         [
           "translat",
           {
-            "_index": 152,
+            "_index": 155,
             "t": {
-              "17": {
+              "23": {
                 "position": [
                   [1231, 12],
                   [1265, 12]
@@ -1744,14 +1823,14 @@
         ],
         [
           "translationmap",
-          { "_index": 153, "t": { "17": { "position": [[1244, 14]] } } }
+          { "_index": 156, "t": { "23": { "position": [[1244, 14]] } } }
         ],
         [
           "true",
           {
-            "_index": 92,
+            "_index": 94,
             "t": {
-              "17": {
+              "23": {
                 "position": [
                   [48, 4],
                   [94, 4]
@@ -1760,15 +1839,15 @@
             }
           }
         ],
-        ["truncat", { "_index": 60, "t": { "6": { "position": [[57, 8]] } } }],
-        ["type", { "_index": 87, "t": { "17": { "position": [[5, 4]] } } }],
+        ["truncat", { "_index": 42, "t": { "7": { "position": [[57, 8]] } } }],
+        ["type", { "_index": 89, "t": { "23": { "position": [[5, 4]] } } }],
         [
           "ultrici",
           {
             "_index": 11,
             "t": {
-              "2": { "position": [[90, 10]] },
-              "6": {
+              "3": { "position": [[90, 10]] },
+              "7": {
                 "position": [
                   [210, 10],
                   [389, 10],
@@ -1794,41 +1873,41 @@
         [
           "us",
           {
-            "_index": 53,
+            "_index": 27,
             "t": {
-              "4": { "position": [[446, 3]] },
-              "6": { "position": [[46, 3]] },
-              "8": { "position": [[66, 3]] }
+              "5": { "position": [[66, 3]] },
+              "7": { "position": [[46, 3]] },
+              "9": { "position": [[446, 3]] }
             }
           }
         ],
-        ["veri", { "_index": 57, "t": { "6": { "position": [[25, 4]] } } }],
-        ["view", { "_index": 65, "t": { "6": { "position": [[114, 5]] } } }],
+        ["veri", { "_index": 40, "t": { "7": { "position": [[25, 4]] } } }],
+        ["view", { "_index": 47, "t": { "7": { "position": [[114, 5]] } } }],
         [
           "want",
           {
-            "_index": 51,
+            "_index": 73,
             "t": {
-              "4": { "position": [[401, 4]] },
-              "17": { "position": [[889, 4]] }
+              "9": { "position": [[401, 4]] },
+              "23": { "position": [[889, 4]] }
             }
           }
         ],
         [
           "welcome.md",
-          { "_index": 41, "t": { "4": { "position": [[245, 10]] } } }
+          { "_index": 64, "t": { "9": { "position": [[245, 10]] } } }
         ],
         [
           "welcome/index.md",
-          { "_index": 42, "t": { "4": { "position": [[267, 16]] } } }
+          { "_index": 65, "t": { "9": { "position": [[267, 16]] } } }
         ],
-        ["well", { "_index": 49, "t": { "4": { "position": [[378, 5]] } } }],
+        ["well", { "_index": 71, "t": { "9": { "position": [[378, 5]] } } }],
         [
           "whether",
           {
-            "_index": 93,
+            "_index": 95,
             "t": {
-              "17": {
+              "23": {
                 "position": [
                   [53, 7],
                   [99, 7],
@@ -1839,9 +1918,9 @@
             }
           }
         ],
-        ["word", { "_index": 132, "t": { "17": { "position": [[919, 5]] } } }],
-        ["yarn", { "_index": 79, "t": { "13": { "position": [[0, 4]] } } }],
-        ["zh", { "_index": 110, "t": { "17": { "position": [[461, 2]] } } }]
+        ["word", { "_index": 135, "t": { "23": { "position": [[919, 5]] } } }],
+        ["yarn", { "_index": 84, "t": { "19": { "position": [[0, 4]] } } }],
+        ["zh", { "_index": 113, "t": { "23": { "position": [[461, 2]] } } }]
       ],
       "pipeline": ["stemmer"]
     }


### PR DESCRIPTION
fixes #49 

# Summary

We show title headers that could be duplicated without additional context such as the URL. This PR adds additional context.

## Before
<img width="1518" alt="Screenshot 2022-10-22 at 3 07 44 PM" src="https://user-images.githubusercontent.com/1854811/197364192-62520273-2474-4bfe-b574-b4fa9b4c709c.png">

## After
<img width="1518" alt="Screenshot 2022-10-22 at 3 06 31 PM" src="https://user-images.githubusercontent.com/1854811/197364193-4aed99a4-029b-479e-be9d-4e1bf25a29ff.png">
