### PR TITLE
fix: adds .yarnrc.yml to ensure local linkage (non pnp use)

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules


### PR DESCRIPTION
## Summary

Adds `.yarnrc.yml` to ensure we use local `node_modules` linker vs. pnp.
