### PR TITLE
Adding validate-peer-dependencies to ensure peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "fs-extra": "^10.1.0",
     "klaw-sync": "^6.0.0",
     "lunr": "^2.3.9",
-    "mark.js": "^8.11.1"
+    "mark.js": "^8.11.1",
+    "validate-peer-dependencies": "^2.2.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.2.1",

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import { normalizeUrl } from "@docusaurus/utils";
 import { LoadContext, Plugin } from "@docusaurus/types";
+import validatePeerDependencies from "validate-peer-dependencies";
 import type { PluginOptions } from "docusaurus-plugin-search-local";
 
 import { getPluginConfig } from "./utils/getPluginConfig";
@@ -8,6 +9,8 @@ import { getGlobalPluginData } from "./utils/getGlobalPluginData";
 import { postBuildFactory } from "./utils/postBuildFactory";
 
 const PLUGIN_NAME = "docusaurus-plugin-search-local";
+
+validatePeerDependencies(__dirname);
 
 export default function DocusaurusSearchLocalPlugin(
   context: LoadContext,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8344,6 +8344,7 @@ __metadata:
     tmp: ^0.2.1
     tslib: ^2.4.0
     typescript: ^4.8.4
+    validate-peer-dependencies: ^2.2.0
     vitest: ^0.24.3
   peerDependencies:
     "@docusaurus/core": ">=2.1.0"
@@ -18669,7 +18670,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"validate-peer-dependencies@npm:^2.0.0":
+"validate-peer-dependencies@npm:^2.0.0, validate-peer-dependencies@npm:^2.2.0":
   version: 2.2.0
   resolution: "validate-peer-dependencies@npm:2.2.0"
   dependencies:


### PR DESCRIPTION
## Summary

Adds `validate-peer-dependencies` package to ensure correct `peerDependencies` are installed in the host package.