### PR TITLE
Adding version tester action

### DIFF
--- a/.github/workflows/version-compatibility-test.yml
+++ b/.github/workflows/version-compatibility-test.yml
@@ -1,8 +1,6 @@
 name: Docusarurus Version Compatibility Test
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/version-compatibility-test.yml
+++ b/.github/workflows/version-compatibility-test.yml
@@ -1,0 +1,17 @@
+name: Docusarurus Version Compatibility Test
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: volta-cli/action@v1
+      - name: Install dependencies
+        run: yarn
+      - name: Run version compatibility test
+        uses: scalvert/docusaurus-version-compatibility@master

--- a/.github/workflows/version-compatibility-test.yml
+++ b/.github/workflows/version-compatibility-test.yml
@@ -14,4 +14,4 @@ jobs:
       - name: Install dependencies
         run: yarn
       - name: Run version compatibility test
-        uses: scalvert/docusaurus-version-compatibility@master
+        uses: docusaurus-version-compatibility@master


### PR DESCRIPTION
This PR adds a test workflow to validate this plugin against all Docusaurus published versions. This needs to be merged to `main` in order to be able to test this.