### PR TITLE
Removing types-only packages from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,8 +109,6 @@
   },
   "peerDependencies": {
     "@docusaurus/core": ">=2.1.0",
-    "@docusaurus/module-type-aliases": ">=2.1.0",
-    "@docusaurus/types": ">=2.1.0",
     "@docusaurus/utils": ">=2.1.0",
     "@docusaurus/utils-validation": ">=2.1.0",
     "react": ">=17.0.2",

--- a/src/server/utils/__snapshots__/getGlobalPluginData.test.ts.snap
+++ b/src/server/utils/__snapshots__/getGlobalPluginData.test.ts.snap
@@ -4,7 +4,7 @@ exports[`getGlobalPluginData > it should generate an index hash when enabled 1`]
 {
   "externalSearchSources": [],
   "highlightSearchTermsOnTargetPage": false,
-  "indexHash": "cd1d2be3",
+  "indexHash": "c0a58bc8",
   "removeDefaultStopWordFilter": false,
   "searchResultContextMaxLength": 50,
   "searchResultLimits": 8,
@@ -25,7 +25,7 @@ exports[`getGlobalPluginData > it should only index blog when enabled 1`] = `
 {
   "externalSearchSources": [],
   "highlightSearchTermsOnTargetPage": false,
-  "indexHash": "5d5e36f4",
+  "indexHash": "256e1fdf",
   "removeDefaultStopWordFilter": false,
   "searchResultContextMaxLength": 50,
   "searchResultLimits": 8,
@@ -46,7 +46,7 @@ exports[`getGlobalPluginData > it should only index docs when enabled 1`] = `
 {
   "externalSearchSources": [],
   "highlightSearchTermsOnTargetPage": false,
-  "indexHash": "0310721d",
+  "indexHash": "cd483c4d",
   "removeDefaultStopWordFilter": false,
   "searchResultContextMaxLength": 50,
   "searchResultLimits": 8,

--- a/src/server/utils/__snapshots__/getIndexHash.test.ts.snap
+++ b/src/server/utils/__snapshots__/getIndexHash.test.ts.snap
@@ -6,6 +6,6 @@ exports[`getIndexHash > getIndexHash({"hashed":true,"indexBlog":true,"blogDir":[
 
 exports[`getIndexHash > getIndexHash({"hashed":true,"indexDocs":true,"docsDir":["/does-not-exist/docs"]}) should return '1' 1`] = `null`;
 
-exports[`getIndexHash > getIndexHash({"hashed":true,"indexDocs":true,"docsDir":["/tmp/docs"]}) should return '0' 1`] = `"c22760a6"`;
+exports[`getIndexHash > getIndexHash({"hashed":true,"indexDocs":true,"docsDir":["/tmp/docs"]}) should return '0' 1`] = `"38805ce5"`;
 
 exports[`getIndexHash > getIndexHash({"hashed":true,"indexDocs":true,"docsDir":["/tmp/index.js"]}) should return '1' 1`] = `null`;

--- a/website/package.json
+++ b/website/package.json
@@ -19,7 +19,7 @@
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^6.2.1",
     "clsx": "^1.1.1",
-    "docusaurus-plugin-search-local": "^0.10.1",
+    "docusaurus-plugin-search-local": "^1.0.0",
     "file-loader": "^6.2.0",
     "prism-react-renderer": "^1.2.1",
     "react": "^17.0.2",

--- a/website/package.json
+++ b/website/package.json
@@ -19,7 +19,7 @@
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^6.2.1",
     "clsx": "^1.1.1",
-    "docusaurus-plugin-search-local": "^1.0.0",
+    "docusaurus-plugin-search-local": "^0.10.1",
     "file-loader": "^6.2.0",
     "prism-react-renderer": "^1.2.1",
     "react": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8121,8 +8121,6 @@ __metadata:
     vitest: ^0.24.3
   peerDependencies:
     "@docusaurus/core": ">=2.1.0"
-    "@docusaurus/module-type-aliases": ">=2.1.0"
-    "@docusaurus/types": ">=2.1.0"
     "@docusaurus/utils": ">=2.1.0"
     "@docusaurus/utils-validation": ">=2.1.0"
     react: ">=17.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8055,7 +8055,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"docusaurus-plugin-search-local@^1.0.0, docusaurus-plugin-search-local@workspace:.":
+"docusaurus-plugin-search-local@npm:^0.10.1":
+  version: 0.10.1
+  resolution: "docusaurus-plugin-search-local@npm:0.10.1"
+  dependencies:
+    "@braintree/sanitize-url": ^6.0.0
+    cheerio: ^1.0.0-rc.11
+    clsx: ^1.1.1
+    debug: ^4.3.4
+    fs-extra: ^10.1.0
+    klaw-sync: ^6.0.0
+    lunr: ^2.3.9
+    mark.js: ^8.11.1
+  peerDependencies:
+    "@docusaurus/core": ">=2.1.0"
+    "@docusaurus/module-type-aliases": ">=2.1.0"
+    "@docusaurus/types": ">=2.1.0"
+    "@docusaurus/utils": ">=2.1.0"
+    "@docusaurus/utils-validation": ">=2.1.0"
+    react: ">=17.0.2"
+    react-dom: ">=17.0.2"
+  checksum: 3e0ee0c74378ee8b782a028bb292706fd5469cf81b10485be9e7797237cc437fad367de578dfed546f465c81791f1a55acda6a7d401cf8bf2cd5dfc0dd926440
+  languageName: node
+  linkType: hard
+
+"docusaurus-plugin-search-local@workspace:.":
   version: 0.0.0-use.local
   resolution: "docusaurus-plugin-search-local@workspace:."
   dependencies:
@@ -18823,7 +18847,7 @@ __metadata:
     "@mdx-js/react": ^1.6.21
     "@svgr/webpack": ^6.2.1
     clsx: ^1.1.1
-    docusaurus-plugin-search-local: ^1.0.0
+    docusaurus-plugin-search-local: ^0.10.1
     file-loader: ^6.2.0
     prism-react-renderer: ^1.2.1
     react: ^17.0.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -8055,31 +8055,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"docusaurus-plugin-search-local@npm:^0.10.1":
-  version: 0.10.1
-  resolution: "docusaurus-plugin-search-local@npm:0.10.1"
-  dependencies:
-    "@braintree/sanitize-url": ^6.0.0
-    cheerio: ^1.0.0-rc.11
-    clsx: ^1.1.1
-    debug: ^4.3.4
-    fs-extra: ^10.1.0
-    klaw-sync: ^6.0.0
-    lunr: ^2.3.9
-    mark.js: ^8.11.1
-  peerDependencies:
-    "@docusaurus/core": ">=2.1.0"
-    "@docusaurus/module-type-aliases": ">=2.1.0"
-    "@docusaurus/types": ">=2.1.0"
-    "@docusaurus/utils": ">=2.1.0"
-    "@docusaurus/utils-validation": ">=2.1.0"
-    react: ">=17.0.2"
-    react-dom: ">=17.0.2"
-  checksum: 3e0ee0c74378ee8b782a028bb292706fd5469cf81b10485be9e7797237cc437fad367de578dfed546f465c81791f1a55acda6a7d401cf8bf2cd5dfc0dd926440
-  languageName: node
-  linkType: hard
-
-"docusaurus-plugin-search-local@workspace:.":
+"docusaurus-plugin-search-local@^1.0.0, docusaurus-plugin-search-local@workspace:.":
   version: 0.0.0-use.local
   resolution: "docusaurus-plugin-search-local@workspace:."
   dependencies:
@@ -18849,7 +18825,7 @@ __metadata:
     "@mdx-js/react": ^1.6.21
     "@svgr/webpack": ^6.2.1
     clsx: ^1.1.1
-    docusaurus-plugin-search-local: ^0.10.1
+    docusaurus-plugin-search-local: ^1.0.0
     file-loader: ^6.2.0
     prism-react-renderer: ^1.2.1
     react: ^17.0.2


### PR DESCRIPTION
# Summary

Removing types-only packages that were incorrectly added as `peerDependencies`.
