### PR TITLE
Fixing links to search results if hash is present

### DIFF
--- a/src/client/theme/SearchModal/SearchResult.tsx
+++ b/src/client/theme/SearchModal/SearchResult.tsx
@@ -117,7 +117,7 @@ const SearchResult: React.FC<SuggestionTemplateProps> = (props) => {
       url += `?${buildDestinationQueryParams(tokens)}`;
     }
     if (h) {
-      url += h;
+      url = h;
     }
 
     history.push(url);

--- a/src/client/theme/SearchPage/SearchPage.tsx
+++ b/src/client/theme/SearchPage/SearchPage.tsx
@@ -168,7 +168,7 @@ function SearchResultItem({
     <article className={styles.searchResultItem}>
       <h2>
         <Link
-          to={document.u + (document.h || "")}
+          to={document.h ? document.h : document.u}
           dangerouslySetInnerHTML={{
             __html: isContent
               ? highlight(articleTitle, tokens)


### PR DESCRIPTION
For some reason my search index after docusaurus build contains u and h that are the same except h also has a hash, so the following code will always produce wrong links for any search result that's a deep link. The fix resolves the problem. 

```
{"i":4,"t":"Introduction","u":"/blog/2024/05/01/xyz","h":"/blog/2024/05/01/xyz#introduction","p":2}
```

The original code makes sense if the search-index.json h entry would only contain the hash and nothing else but that's not what I get. Please review and let me know if there's some other configuration setting that fixes this.