### PR TITLE
Update to be compatible with Cheerio 1.0.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@braintree/sanitize-url": "^6.0.0",
-    "cheerio": "^1.0.0-rc.11",
+    "cheerio": "^1.0.0",
     "clsx": "^1.1.1",
     "debug": "^4.3.4",
     "fs-extra": "^10.1.0",
@@ -101,7 +101,7 @@
     "react-dom": ">=18.2.0"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=18.17"
   },
   "volta": {
     "node": "18.18.2",

--- a/src/server/utils/__snapshots__/getIndexHash.test.ts.snap
+++ b/src/server/utils/__snapshots__/getIndexHash.test.ts.snap
@@ -6,6 +6,6 @@ exports[`getIndexHash > getIndexHash({"hashed":true,"indexBlog":true,"blogDir":[
 
 exports[`getIndexHash > getIndexHash({"hashed":true,"indexDocs":true,"docsDir":["/does-not-exist/docs"]}) should return '1' 1`] = `null`;
 
-exports[`getIndexHash > getIndexHash({"hashed":true,"indexDocs":true,"docsDir":["/tmp/docs"]}) should return '0' 1`] = `"9de0582a"`;
+exports[`getIndexHash > getIndexHash({"hashed":true,"indexDocs":true,"docsDir":["/tmp/docs"]}) should return '0' 1`] = `"c9c4419d"`;
 
 exports[`getIndexHash > getIndexHash({"hashed":true,"indexDocs":true,"docsDir":["/tmp/index.js"]}) should return '1' 1`] = `null`;

--- a/src/server/utils/getCondensedText.test.ts
+++ b/src/server/utils/getCondensedText.test.ts
@@ -1,4 +1,4 @@
-import cheerio from "cheerio";
+import * as cheerio from "cheerio";
 import { getCondensedText } from "./getCondensedText";
 
 describe("getCondensedText", () => {

--- a/src/server/utils/getCondensedText.ts
+++ b/src/server/utils/getCondensedText.ts
@@ -1,3 +1,4 @@
+import { type AnyNode } from "domhandler";
 import * as cheerio from "cheerio";
 
 // We prepend and append whitespace for these tags.
@@ -42,10 +43,10 @@ const BLOCK_TAGS = new Set([
 ]);
 
 export function getCondensedText(
-  element: cheerio.AnyNode | cheerio.AnyNode[],
+  element: AnyNode | AnyNode[],
   $: cheerio.CheerioAPI
 ): string {
-  const getText = (element: cheerio.AnyNode | cheerio.AnyNode[]): string => {
+  const getText = (element: AnyNode | AnyNode[]): string => {
     if (Array.isArray(element)) {
       return element.map((item) => getText(item)).join("");
     }

--- a/src/server/utils/getIndexHash.ts
+++ b/src/server/utils/getIndexHash.ts
@@ -1,9 +1,9 @@
-import crypto from "crypto";
-import fs from "fs";
-import path from "path";
-import klawSync from "klaw-sync";
-import type { PluginConfig } from "../../types";
-import { debugInfo } from "./debug";
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import klawSync from 'klaw-sync';
+import type { PluginConfig } from '../../types';
+import { debugInfo } from './debug';
 
 export function getIndexHash(config: PluginConfig): string | null {
   if (!config.hashed) {
@@ -12,8 +12,8 @@ export function getIndexHash(config: PluginConfig): string | null {
   const files: klawSync.Item[] = [];
 
   const scanFiles = (
-    flagField: "indexDocs" | "indexBlog",
-    dirField: "docsDir" | "blogDir"
+    flagField: 'indexDocs' | 'indexBlog',
+    dirField: 'docsDir' | 'blogDir',
   ): void => {
     if (config[flagField]) {
       for (const dir of config[dirField]) {
@@ -28,11 +28,11 @@ export function getIndexHash(config: PluginConfig): string | null {
     }
   };
 
-  scanFiles("indexDocs", "docsDir");
-  scanFiles("indexBlog", "blogDir");
+  scanFiles('indexDocs', 'docsDir');
+  scanFiles('indexBlog', 'blogDir');
 
   if (files.length > 0) {
-    const md5sum = crypto.createHash("md5");
+    const md5sum = crypto.createHash('md5');
 
     // The version of this plugin should be counted in hash,
     // since the index maybe changed between versions. Need to
@@ -42,22 +42,22 @@ export function getIndexHash(config: PluginConfig): string | null {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const pluginVersion = require(path.resolve(
       __dirname,
-      "../../../package.json"
+      '../../../package.json',
     )).version;
-    debugInfo("using docusaurus-plugin-search-local v%s", pluginVersion);
-    md5sum.update(pluginVersion, "utf8");
+    debugInfo('using docusaurus-plugin-search-local v%s', pluginVersion);
+    md5sum.update(pluginVersion, 'utf8');
 
     for (const item of files) {
       md5sum.update(fs.readFileSync(item.path));
     }
 
-    const indexHash = md5sum.digest("hex").substring(0, 8);
-    debugInfo("the index hash is %j", indexHash);
+    const indexHash = md5sum.digest('hex').substring(0, 8);
+    debugInfo('the index hash is %j', indexHash);
     return indexHash;
   }
   return null;
 }
 
 function markdownFilter(item: klawSync.Item): boolean {
-  return item.path.endsWith(".md");
+  return item.path.endsWith('.md');
 }

--- a/src/server/utils/parse.ts
+++ b/src/server/utils/parse.ts
@@ -1,4 +1,4 @@
-import cheerio from "cheerio";
+import * as cheerio from "cheerio";
 import { ParsedDocument } from "../../types";
 import { parseDocument } from "./parseDocument";
 import { parsePage } from "./parsePage";

--- a/src/server/utils/parseDocument.test.ts
+++ b/src/server/utils/parseDocument.test.ts
@@ -1,4 +1,4 @@
-import cheerio from "cheerio";
+import * as cheerio from "cheerio";
 import { ParsedDocument } from "../../types";
 import { parseDocument } from "./parseDocument";
 

--- a/src/server/utils/parsePage.test.ts
+++ b/src/server/utils/parsePage.test.ts
@@ -1,4 +1,4 @@
-import cheerio from "cheerio";
+import * as cheerio from "cheerio";
 import { ParsedDocument } from "../../types";
 import { parsePage } from "./parsePage";
 

--- a/src/server/utils/parsePage.ts
+++ b/src/server/utils/parsePage.ts
@@ -1,3 +1,4 @@
+import { type AnyNode } from "domhandler";
 import * as cheerio from "cheerio";
 import { ParsedDocument } from "../../types";
 import { debugWarn } from "./debug";
@@ -29,7 +30,7 @@ export function parsePage($: cheerio.CheerioAPI, url: string): ParsedDocument {
         hash: "",
         content:
           $main.length > 0
-            ? getCondensedText($main.get(0) as cheerio.AnyNode, $).trim()
+            ? getCondensedText($main.get(0) as AnyNode, $).trim()
             : "",
       },
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -6626,6 +6626,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cheerio@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "cheerio@npm:1.0.0"
+  dependencies:
+    cheerio-select: ^2.1.0
+    dom-serializer: ^2.0.0
+    domhandler: ^5.0.3
+    domutils: ^3.1.0
+    encoding-sniffer: ^0.2.0
+    htmlparser2: ^9.1.0
+    parse5: ^7.1.2
+    parse5-htmlparser2-tree-adapter: ^7.0.0
+    parse5-parser-stream: ^7.1.2
+    undici: ^6.19.5
+    whatwg-mimetype: ^4.0.0
+  checksum: ade4344811dcad5b5d78392506ef6bab1900c13a65222c869e745a38370d287f4b94838ac6d752883a84d937edb62b5bd0deaf70e6f38054acbfe3da4881574a
+  languageName: node
+  linkType: hard
+
 "cheerio@npm:^1.0.0-rc.11, cheerio@npm:^1.0.0-rc.12":
   version: 1.0.0-rc.12
   resolution: "cheerio@npm:1.0.0-rc.12"
@@ -7917,7 +7936,7 @@ __metadata:
     "@types/tmp": ^0.2.3
     "@typescript-eslint/eslint-plugin": ^6.11.0
     "@typescript-eslint/parser": ^6.11.0
-    cheerio: ^1.0.0-rc.11
+    cheerio: ^1.0.0
     clsx: ^1.1.1
     copyfiles: ^2.4.0
     debug: ^4.3.4
@@ -8037,7 +8056,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"domutils@npm:^3.0.1":
+"domutils@npm:^3.0.1, domutils@npm:^3.1.0":
   version: 3.1.0
   resolution: "domutils@npm:3.1.0"
   dependencies:
@@ -8151,6 +8170,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"encoding-sniffer@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "encoding-sniffer@npm:0.2.0"
+  dependencies:
+    iconv-lite: ^0.6.3
+    whatwg-encoding: ^3.1.1
+  checksum: 05ad76b674066e62abc80427eb9e89ecf5ed50f4d20c392f7465992d309215687e3ae1ae8b5d5694fb258f4517c759694c3b413d6c724e1024e1cf98750390eb
+  languageName: node
+  linkType: hard
+
 "encoding@npm:^0.1.12, encoding@npm:^0.1.13":
   version: 0.1.13
   resolution: "encoding@npm:0.1.13"
@@ -8191,7 +8220,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"entities@npm:^4.2.0, entities@npm:^4.4.0":
+"entities@npm:^4.2.0, entities@npm:^4.4.0, entities@npm:^4.5.0":
   version: 4.5.0
   resolution: "entities@npm:4.5.0"
   checksum: 853f8ebd5b425d350bffa97dd6958143179a5938352ccae092c62d1267c4e392a039be1bae7d51b6e4ffad25f51f9617531fedf5237f15df302ccfb452cbf2d7
@@ -10185,6 +10214,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"htmlparser2@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "htmlparser2@npm:9.1.0"
+  dependencies:
+    domelementtype: ^2.3.0
+    domhandler: ^5.0.3
+    domutils: ^3.1.0
+    entities: ^4.5.0
+  checksum: e5f8d5193967e4a500226f37bdf2c0f858cecb39dde14d0439f24bf2c461a4342778740d988fbaba652b0e4cb6052f7f2e99e69fc1a329a86c629032bb76e7c8
+  languageName: node
+  linkType: hard
+
 "http-cache-semantics@npm:^4.1.0, http-cache-semantics@npm:^4.1.1":
   version: 4.1.1
   resolution: "http-cache-semantics@npm:4.1.1"
@@ -10354,7 +10395,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2":
+"iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2, iconv-lite@npm:^0.6.3":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
   dependencies:
@@ -14299,6 +14340,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse5-parser-stream@npm:^7.1.2":
+  version: 7.1.2
+  resolution: "parse5-parser-stream@npm:7.1.2"
+  dependencies:
+    parse5: ^7.0.0
+  checksum: 75b232d460bce6bd0e35012750a78ef034f40ccf550b7c6cec3122395af6b4553202ad3663ad468cf537ead5a2e13b6727670395fd0ff548faccad1dc2dc93cf
+  languageName: node
+  linkType: hard
+
 "parse5@npm:^5.1.1":
   version: 5.1.1
   resolution: "parse5@npm:5.1.1"
@@ -14313,7 +14363,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse5@npm:^7.0.0, parse5@npm:^7.1.1":
+"parse5@npm:^7.0.0, parse5@npm:^7.1.1, parse5@npm:^7.1.2":
   version: 7.1.2
   resolution: "parse5@npm:7.1.2"
   dependencies:
@@ -17543,6 +17593,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici@npm:^6.19.5":
+  version: 6.19.8
+  resolution: "undici@npm:6.19.8"
+  checksum: 2f812769992a187d9c55809b6943059c0bb1340687a0891f769de02101342dded0b9c8874cd5af4a49daaeba8284101d74a1fbda4de04c604ba7a5f6190b9ea2
+  languageName: node
+  linkType: hard
+
 "unicode-canonical-property-names-ecmascript@npm:^2.0.0":
   version: 2.0.0
   resolution: "unicode-canonical-property-names-ecmascript@npm:2.0.0"
@@ -18372,10 +18429,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"whatwg-encoding@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "whatwg-encoding@npm:3.1.1"
+  dependencies:
+    iconv-lite: 0.6.3
+  checksum: f75a61422421d991e4aec775645705beaf99a16a88294d68404866f65e92441698a4f5b9fa11dd609017b132d7b286c3c1534e2de5b3e800333856325b549e3c
+  languageName: node
+  linkType: hard
+
 "whatwg-mimetype@npm:^3.0.0":
   version: 3.0.0
   resolution: "whatwg-mimetype@npm:3.0.0"
   checksum: ce08bbb36b6aaf64f3a84da89707e3e6a31e5ab1c1a2379fd68df79ba712a4ab090904f0b50e6693b0dafc8e6343a6157e40bf18fdffd26e513cf95ee2a59824
+  languageName: node
+  linkType: hard
+
+"whatwg-mimetype@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "whatwg-mimetype@npm:4.0.0"
+  checksum: f97edd4b4ee7e46a379f3fb0e745de29fe8b839307cc774300fd49059fcdd560d38cb8fe21eae5575b8f39b022f23477cc66e40b0355c2851ce84760339cef30
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
1. Minimum NodeJS version is now 18.17.
2. All imports need to be `import * as cheerio ...`.
3. AnyNode now needs to be imported from domhandler directly.